### PR TITLE
fix(modules/music_player): handle `VoiceStateUpdate` events

### DIFF
--- a/internal/modules/music_player/domain/player_state.go
+++ b/internal/modules/music_player/domain/player_state.go
@@ -58,6 +58,13 @@ func (p *PlayerState) SetVoiceChannel(channelID snowflake.ID) {
 	p.VoiceChannelID = channelID
 }
 
+// GetVoiceChannelID returns the current voice channel ID.
+func (p *PlayerState) GetVoiceChannelID() snowflake.ID {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.VoiceChannelID
+}
+
 // SetNotificationChannel updates the notification channel ID.
 func (p *PlayerState) SetNotificationChannel(channelID snowflake.ID) {
 	p.mu.Lock()

--- a/internal/modules/music_player/presentation/event_handlers.go
+++ b/internal/modules/music_player/presentation/event_handlers.go
@@ -1,0 +1,59 @@
+package presentation
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/usecases"
+)
+
+// EventHandlers handles Discord gateway events for the music player.
+type EventHandlers struct {
+	botID        snowflake.ID
+	voiceChannel *usecases.VoiceChannelService
+}
+
+// NewEventHandlers creates a new EventHandlers.
+func NewEventHandlers(
+	botID snowflake.ID,
+	voiceChannel *usecases.VoiceChannelService,
+) *EventHandlers {
+	return &EventHandlers{
+		botID:        botID,
+		voiceChannel: voiceChannel,
+	}
+}
+
+// HandleVoiceStateUpdate handles VoiceStateUpdate events for the bot.
+func (h *EventHandlers) HandleVoiceStateUpdate(
+	_ *discordgo.Session,
+	event *discordgo.VoiceStateUpdate,
+) {
+	// Only handle updates for the bot itself
+	if event.UserID != h.botID.String() {
+		return
+	}
+
+	guildID, err := snowflake.Parse(event.GuildID)
+	if err != nil {
+		slog.Error("failed to parse guild ID in voice state update", "error", err)
+		return
+	}
+
+	// Parse the channel ID - nil means disconnected
+	var newChannelID *snowflake.ID
+	if event.ChannelID != "" {
+		id, err := snowflake.Parse(event.ChannelID)
+		if err != nil {
+			slog.Error("failed to parse channel ID in voice state update", "error", err)
+			return
+		}
+		newChannelID = &id
+	}
+
+	h.voiceChannel.HandleBotVoiceStateChange(usecases.BotVoiceStateChangeInput{
+		GuildID:      guildID,
+		NewChannelID: newChannelID,
+	})
+}


### PR DESCRIPTION
## Changes

### Voice State Handling

- Added `HandleBotVoiceStateChange` method to `VoiceChannelService` to handle external voice state changes
- On disconnect: publishes `PlaybackFinishedEvent` to delete "Now Playing" message, then deletes player state
- On channel move: updates `VoiceChannelID` in player state

### Lavalink Event Buffering

- Added `voiceEventBuffer` to handle out-of-order `VoiceStateUpdate` and `VoiceServerUpdate` events
- Events are buffered until both are received, then forwarded to Lavalink together
- Prevents `"Partial Lavalink voice state: VoiceState(sessionId=)"` errors

### Architecture

- State management moved from infrastructure (`LavalinkAdapter`) to application layer (`VoiceChannelService`)
- Added `presentation.EventHandlers` to route Discord events to application layer
- Added thread-safe `GetVoiceChannelID` getter to `PlayerState`
