### PR TITLE
ci: split CI and container image build workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,17 +1,5 @@
 name: CI
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - ".ko.yaml"
-      - ".golangci.yaml"
-      - ".github/workflows/ci.yaml"
   pull_request:
     branches:
       - main
@@ -63,45 +51,3 @@ jobs:
           go-version-file: "go.mod"
       - name: Build
         run: go build -v ./cmd/sgrbot
-  container:
-    name: Build and Push Container Image
-    runs-on: ubuntu-latest
-    needs: [lint, test, build-check]
-    if: github.event_name == 'push'
-    permissions:
-      contents: read
-      packages: write
-    env:
-      KO_DOCKER_REPO: ghcr.io/sglre6355/sgrbot
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: "go.mod"
-      - name: Set up ko
-        uses: ko-build/setup-ko@v0.9
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-      - name: Determine tags and version
-        id: meta
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "tags=${{ github.ref_name }},latest" >> "$GITHUB_OUTPUT"
-            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tags=latest" >> "$GITHUB_OUTPUT"
-            echo "version=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Build and push
-        env:
-          VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          ko build ./cmd/sgrbot \
-            --bare \
-            --tags=${{ steps.meta.outputs.tags }}

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,57 @@
+name: Container
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".ko.yaml"
+      - ".github/workflows/container.yaml"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  container:
+    name: Build and Push Container Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      KO_DOCKER_REPO: ghcr.io/sglre6355/sgrbot
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Set up ko
+        uses: ko-build/setup-ko@v0.9
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Determine tags and version
+        id: meta
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "tags=${{ github.ref_name }},latest" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=latest" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build and push
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          ko build ./cmd/sgrbot \
+            --bare \
+            --tags=${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Separate code quality checks (lint, test, build check) from container builds into distinct workflow files. CI runs only on PRs, container image build runs only on push to main and tags.