### PR TITLE
refactor(modules/music_player): enforce DDD layer boundaries

### DIFF
--- a/internal/modules/music_player/application/events/handlers.go
+++ b/internal/modules/music_player/application/events/handlers.go
@@ -139,7 +139,7 @@ func (h *PlaybackEventHandler) handleTrackEnded(ctx context.Context, event Track
 	// Delete the old "Now Playing" message before playing next
 	nowPlayingMsgID := state.GetNowPlayingMessageID()
 	if nowPlayingMsgID != nil {
-		h.bus.Publish(PlaybackFinishedEvent{
+		h.bus.PublishPlaybackFinished(PlaybackFinishedEvent{
 			GuildID:               event.GuildID,
 			NotificationChannelID: state.NotificationChannelID,
 			LastMessageID:         nowPlayingMsgID,
@@ -157,7 +157,7 @@ func (h *PlaybackEventHandler) handleTrackEnded(ctx context.Context, event Track
 		)
 
 		// Publish error notification if we have a channel
-		h.bus.Publish(PlaybackFinishedEvent{
+		h.bus.PublishPlaybackFinished(PlaybackFinishedEvent{
 			GuildID:               event.GuildID,
 			NotificationChannelID: state.NotificationChannelID,
 			LastMessageID:         state.GetNowPlayingMessageID(),

--- a/internal/modules/music_player/application/events/handlers_test.go
+++ b/internal/modules/music_player/application/events/handlers_test.go
@@ -134,7 +134,7 @@ func TestPlaybackEventHandler_TrackEnqueued_WhenIdle_StartsPlayback(t *testing.T
 	defer handler.Stop()
 
 	// Publish event with wasIdle=true
-	bus.Publish(TrackEnqueuedEvent{
+	bus.PublishTrackEnqueued(TrackEnqueuedEvent{
 		GuildID: snowflake.ID(1),
 		Track:   mockTrack("track-1"),
 		WasIdle: true,
@@ -171,7 +171,7 @@ func TestPlaybackEventHandler_TrackEnqueued_WhenNotIdle_DoesNotStartPlayback(t *
 	defer handler.Stop()
 
 	// Publish event with wasIdle=false
-	bus.Publish(TrackEnqueuedEvent{
+	bus.PublishTrackEnqueued(TrackEnqueuedEvent{
 		GuildID: snowflake.ID(1),
 		Track:   mockTrack("track-1"),
 		WasIdle: false,
@@ -212,7 +212,7 @@ func TestPlaybackEventHandler_TrackEnded_Finished_AdvancesQueue(t *testing.T) {
 	defer handler.Stop()
 
 	// Publish track ended with "finished" reason
-	bus.Publish(TrackEndedEvent{
+	bus.PublishTrackEnded(TrackEndedEvent{
 		GuildID: guildID,
 		Reason:  TrackEndFinished,
 	})
@@ -252,7 +252,7 @@ func TestPlaybackEventHandler_TrackEnded_Stopped_DoesNotAdvanceQueue(t *testing.
 	defer handler.Stop()
 
 	// Publish track ended with "stopped" reason (user-initiated stop)
-	bus.Publish(TrackEndedEvent{
+	bus.PublishTrackEnded(TrackEndedEvent{
 		GuildID: guildID,
 		Reason:  TrackEndStopped,
 	})
@@ -319,7 +319,7 @@ func TestNotificationEventHandler_PlaybackStarted_SendsNowPlaying(t *testing.T) 
 	defer handler.Stop()
 
 	track := mockTrack("track-1")
-	bus.Publish(PlaybackStartedEvent{
+	bus.PublishPlaybackStarted(PlaybackStartedEvent{
 		GuildID:               guildID,
 		Track:                 track,
 		NotificationChannelID: snowflake.ID(200),
@@ -354,7 +354,7 @@ func TestNotificationEventHandler_PlaybackStarted_StoresMessageID(t *testing.T) 
 
 	handler.Start(t.Context())
 
-	bus.Publish(PlaybackStartedEvent{
+	bus.PublishPlaybackStarted(PlaybackStartedEvent{
 		GuildID:               guildID,
 		Track:                 mockTrack("track-1"),
 		NotificationChannelID: snowflake.ID(200),
@@ -386,7 +386,7 @@ func TestNotificationEventHandler_PlaybackFinished_DeletesMessage(t *testing.T) 
 
 	handler.Start(t.Context())
 
-	bus.Publish(PlaybackFinishedEvent{
+	bus.PublishPlaybackFinished(PlaybackFinishedEvent{
 		GuildID:               guildID,
 		NotificationChannelID: snowflake.ID(200),
 		LastMessageID:         &messageID,
@@ -421,7 +421,7 @@ func TestNotificationEventHandler_PlaybackFinished_NilMessageID_DoesNotDelete(t 
 
 	handler.Start(t.Context())
 
-	bus.Publish(PlaybackFinishedEvent{
+	bus.PublishPlaybackFinished(PlaybackFinishedEvent{
 		GuildID:               snowflake.ID(1),
 		NotificationChannelID: snowflake.ID(200),
 		LastMessageID:         nil,

--- a/internal/modules/music_player/application/events/types.go
+++ b/internal/modules/music_player/application/events/types.go
@@ -1,68 +1,23 @@
 package events
 
 import (
-	"github.com/disgoorg/snowflake/v2"
-	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/ports"
 )
 
-// Event is the interface that all events must implement.
-type Event interface {
-	eventType() string
-}
+// Re-export event types from ports for use by event handlers.
+type (
+	TrackEnqueuedEvent    = ports.TrackEnqueuedEvent
+	PlaybackStartedEvent  = ports.PlaybackStartedEvent
+	PlaybackFinishedEvent = ports.PlaybackFinishedEvent
+	TrackEndedEvent       = ports.TrackEndedEvent
+	TrackEndReason        = ports.TrackEndReason
+)
 
-// TrackEnqueuedEvent is published when a track is added to the queue.
-type TrackEnqueuedEvent struct {
-	GuildID snowflake.ID
-	Track   *domain.Track
-	WasIdle bool // true if no track was playing when this was enqueued
-}
-
-func (e TrackEnqueuedEvent) eventType() string { return "TrackEnqueued" }
-
-// PlaybackStartedEvent is published when a track starts playing.
-type PlaybackStartedEvent struct {
-	GuildID               snowflake.ID
-	Track                 *domain.Track
-	NotificationChannelID snowflake.ID
-}
-
-func (e PlaybackStartedEvent) eventType() string { return "PlaybackStarted" }
-
-// PlaybackFinishedEvent is published when a track finishes playing.
-// This signals that the "Now Playing" message should be deleted.
-type PlaybackFinishedEvent struct {
-	GuildID               snowflake.ID
-	NotificationChannelID snowflake.ID
-	LastMessageID         *snowflake.ID // "Now Playing" message to delete
-}
-
-func (e PlaybackFinishedEvent) eventType() string { return "PlaybackFinished" }
-
-// TrackEndedEvent is published when a track finishes (from Lavalink).
-type TrackEndedEvent struct {
-	GuildID snowflake.ID
-	Reason  TrackEndReason
-}
-
-func (e TrackEndedEvent) eventType() string { return "TrackEnded" }
-
-// TrackEndReason represents why a track ended.
-type TrackEndReason string
-
+// Re-export TrackEndReason constants.
 const (
-	// TrackEndFinished means the track finished normally.
-	TrackEndFinished TrackEndReason = "finished"
-	// TrackEndLoadFailed means the track failed to load.
-	TrackEndLoadFailed TrackEndReason = "load_failed"
-	// TrackEndStopped means the track was stopped by the user.
-	TrackEndStopped TrackEndReason = "stopped"
-	// TrackEndReplaced means the track was replaced by another.
-	TrackEndReplaced TrackEndReason = "replaced"
-	// TrackEndCleanup means the track was cleaned up.
-	TrackEndCleanup TrackEndReason = "cleanup"
+	TrackEndFinished   = ports.TrackEndFinished
+	TrackEndLoadFailed = ports.TrackEndLoadFailed
+	TrackEndStopped    = ports.TrackEndStopped
+	TrackEndReplaced   = ports.TrackEndReplaced
+	TrackEndCleanup    = ports.TrackEndCleanup
 )
-
-// ShouldAdvanceQueue returns true if this end reason should advance the queue.
-func (r TrackEndReason) ShouldAdvanceQueue() bool {
-	return r == TrackEndFinished || r == TrackEndLoadFailed
-}

--- a/internal/modules/music_player/application/ports/event_publisher.go
+++ b/internal/modules/music_player/application/ports/event_publisher.go
@@ -1,0 +1,70 @@
+package ports
+
+import (
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
+)
+
+// EventPublisher defines the interface for publishing events asynchronously.
+type EventPublisher interface {
+	// PublishTrackEnqueued publishes an event when a track is added to the queue.
+	PublishTrackEnqueued(event TrackEnqueuedEvent)
+
+	// PublishPlaybackStarted publishes an event when a track starts playing.
+	PublishPlaybackStarted(event PlaybackStartedEvent)
+
+	// PublishPlaybackFinished publishes an event when playback finishes.
+	PublishPlaybackFinished(event PlaybackFinishedEvent)
+
+	// PublishTrackEnded publishes an event when a track ends (from audio player).
+	PublishTrackEnded(event TrackEndedEvent)
+}
+
+// TrackEnqueuedEvent is published when a track is added to the queue.
+type TrackEnqueuedEvent struct {
+	GuildID snowflake.ID
+	Track   *domain.Track
+	WasIdle bool // true if no track was playing when this was enqueued
+}
+
+// PlaybackStartedEvent is published when a track starts playing.
+type PlaybackStartedEvent struct {
+	GuildID               snowflake.ID
+	Track                 *domain.Track
+	NotificationChannelID snowflake.ID
+}
+
+// PlaybackFinishedEvent is published when a track finishes playing.
+// This signals that the "Now Playing" message should be deleted.
+type PlaybackFinishedEvent struct {
+	GuildID               snowflake.ID
+	NotificationChannelID snowflake.ID
+	LastMessageID         *snowflake.ID // "Now Playing" message to delete
+}
+
+// TrackEndedEvent is published when a track ends (from Lavalink).
+type TrackEndedEvent struct {
+	GuildID snowflake.ID
+	Reason  TrackEndReason
+}
+
+// TrackEndReason represents why a track ended.
+type TrackEndReason string
+
+const (
+	// TrackEndFinished means the track finished normally.
+	TrackEndFinished TrackEndReason = "finished"
+	// TrackEndLoadFailed means the track failed to load.
+	TrackEndLoadFailed TrackEndReason = "load_failed"
+	// TrackEndStopped means the track was stopped by the user.
+	TrackEndStopped TrackEndReason = "stopped"
+	// TrackEndReplaced means the track was replaced by another.
+	TrackEndReplaced TrackEndReason = "replaced"
+	// TrackEndCleanup means the track was cleaned up.
+	TrackEndCleanup TrackEndReason = "cleanup"
+)
+
+// ShouldAdvanceQueue returns true if this end reason should advance the queue.
+func (r TrackEndReason) ShouldAdvanceQueue() bool {
+	return r == TrackEndFinished || r == TrackEndLoadFailed
+}

--- a/internal/modules/music_player/application/usecases/autocomplete.go
+++ b/internal/modules/music_player/application/usecases/autocomplete.go
@@ -1,0 +1,63 @@
+package usecases
+
+import (
+	"context"
+
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/ports"
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
+)
+
+// GetQueueTracksInput contains the input for the GetQueueTracks use case.
+type GetQueueTracksInput struct {
+	GuildID snowflake.ID
+}
+
+// GetQueueTracksOutput contains the output for the GetQueueTracks use case.
+type GetQueueTracksOutput struct {
+	Tracks []*domain.Track
+}
+
+// AutocompleteService handles autocomplete-related operations.
+type AutocompleteService struct {
+	repo        domain.PlayerStateRepository
+	trackLoader ports.TrackResolver
+}
+
+// NewAutocompleteService creates a new AutocompleteService.
+func NewAutocompleteService(
+	repo domain.PlayerStateRepository,
+	trackLoader ports.TrackResolver,
+) *AutocompleteService {
+	return &AutocompleteService{
+		repo:        repo,
+		trackLoader: trackLoader,
+	}
+}
+
+// GetQueueTracks returns the current queue tracks for autocomplete suggestions.
+func (s *AutocompleteService) GetQueueTracks(input GetQueueTracksInput) *GetQueueTracksOutput {
+	state := s.repo.Get(input.GuildID)
+	if state == nil {
+		return &GetQueueTracksOutput{Tracks: nil}
+	}
+
+	return &GetQueueTracksOutput{
+		Tracks: state.Queue.List(),
+	}
+}
+
+// SearchTracks searches for tracks matching the query.
+// This is a pass-through to TrackLoaderService.SearchTracks.
+func (s *AutocompleteService) SearchTracks(
+	ctx context.Context,
+	input SearchTracksInput,
+) (*SearchTracksOutput, error) {
+	if s.trackLoader == nil {
+		return &SearchTracksOutput{Tracks: nil}, nil
+	}
+
+	// Use TrackLoaderService's search functionality
+	loader := NewTrackLoaderService(s.trackLoader)
+	return loader.SearchTracks(ctx, input)
+}

--- a/internal/modules/music_player/application/usecases/playback_test.go
+++ b/internal/modules/music_player/application/usecases/playback_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/disgoorg/snowflake/v2"
-	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/events"
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/ports"
 )
 
 func TestPlaybackService_Pause(t *testing.T) {
@@ -367,14 +367,14 @@ func TestPlaybackService_Skip(t *testing.T) {
 
 func TestTrackEndReason_ShouldAdvanceQueue(t *testing.T) {
 	tests := []struct {
-		reason   events.TrackEndReason
+		reason   ports.TrackEndReason
 		expected bool
 	}{
-		{events.TrackEndFinished, true},
-		{events.TrackEndLoadFailed, true},
-		{events.TrackEndStopped, false},
-		{events.TrackEndReplaced, false},
-		{events.TrackEndCleanup, false},
+		{ports.TrackEndFinished, true},
+		{ports.TrackEndLoadFailed, true},
+		{ports.TrackEndStopped, false},
+		{ports.TrackEndReplaced, false},
+		{ports.TrackEndCleanup, false},
 	}
 
 	for _, tt := range tests {

--- a/internal/modules/music_player/application/usecases/test_helpers_test.go
+++ b/internal/modules/music_player/application/usecases/test_helpers_test.go
@@ -115,3 +115,26 @@ func (m *mockVoiceStateProvider) GetUserVoiceChannel(
 	}
 	return m.channels[userID], nil
 }
+
+type mockEventPublisher struct {
+	trackEnqueued    []ports.TrackEnqueuedEvent
+	playbackStarted  []ports.PlaybackStartedEvent
+	playbackFinished []ports.PlaybackFinishedEvent
+	trackEnded       []ports.TrackEndedEvent
+}
+
+func (m *mockEventPublisher) PublishTrackEnqueued(event ports.TrackEnqueuedEvent) {
+	m.trackEnqueued = append(m.trackEnqueued, event)
+}
+
+func (m *mockEventPublisher) PublishPlaybackStarted(event ports.PlaybackStartedEvent) {
+	m.playbackStarted = append(m.playbackStarted, event)
+}
+
+func (m *mockEventPublisher) PublishPlaybackFinished(event ports.PlaybackFinishedEvent) {
+	m.playbackFinished = append(m.playbackFinished, event)
+}
+
+func (m *mockEventPublisher) PublishTrackEnded(event ports.TrackEndedEvent) {
+	m.trackEnded = append(m.trackEnded, event)
+}

--- a/internal/modules/music_player/application/usecases/types.go
+++ b/internal/modules/music_player/application/usecases/types.go
@@ -1,0 +1,17 @@
+package usecases
+
+import (
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
+)
+
+// Re-export domain types for presentation layer use.
+// This allows presentation to depend only on usecases without importing domain directly.
+
+// Track is an alias for domain.Track.
+type Track = domain.Track
+
+// TrackID is an alias for domain.TrackID.
+type TrackID = domain.TrackID
+
+// PlayerStateRepository is an alias for domain.PlayerStateRepository.
+type PlayerStateRepository = domain.PlayerStateRepository

--- a/internal/modules/music_player/presentation/handlers.go
+++ b/internal/modules/music_player/presentation/handlers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/sglre6355/sgrbot/internal/bot"
 	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/usecases"
-	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
 )
 
 // Embed colors.
@@ -522,7 +521,7 @@ func respondResumed(r bot.Responder) error {
 	})
 }
 
-func respondSkipped(r bot.Responder, track *domain.Track) error {
+func respondSkipped(r bot.Responder, track *usecases.Track) error {
 	var description string
 	if track.URI != "" {
 		description = fmt.Sprintf("Skipped [%s](%s).", track.Title, track.URI)
@@ -543,7 +542,7 @@ func respondSkipped(r bot.Responder, track *domain.Track) error {
 	})
 }
 
-func respondQueueRemoved(r bot.Responder, track *domain.Track) error {
+func respondQueueRemoved(r bot.Responder, track *usecases.Track) error {
 	var description string
 	if track.URI != "" {
 		description = fmt.Sprintf("Removed [%s](%s).", track.Title, track.URI)
@@ -578,7 +577,7 @@ func respondQueueCleared(r bot.Responder) error {
 	})
 }
 
-func respondQueueAdded(r bot.Responder, track *domain.Track) error {
+func respondQueueAdded(r bot.Responder, track *usecases.Track) error {
 	var description string
 	if track.URI != "" {
 		description = fmt.Sprintf("Added [%s](%s) to the queue.", track.Title, track.URI)


### PR DESCRIPTION
### Restructure imports to follow proper DDD layer dependencies:
- Presentation layer now only imports from application/usecases
- Infrastructure layer only imports from domain and application/ports
- Application/usecases only imports from domain and ports
- Application/events only imports from domain and ports

### Key changes:
- Create `EventPublisher` port interface for event publishing abstraction
- Update `events.Bus` to implement `ports.EventPublisher`
- Create `AutocompleteService` usecase to encapsulate repository access
- Re-export domain types in `usecases/types.go` for presentation layer
- Remove direct domain imports from presentation layer
- Remove events package import from infrastructure layer