### PR TITLE
fix(modules/music_player): delete now playing message from correct channel on notification channel switch

### DIFF
--- a/internal/modules/music_player/application/events/handlers_test.go
+++ b/internal/modules/music_player/application/events/handlers_test.go
@@ -364,8 +364,8 @@ func TestNotificationEventHandler_PlaybackStarted_StoresMessageID(t *testing.T) 
 	time.Sleep(100 * time.Millisecond)
 	handler.Stop()
 
-	if state.GetNowPlayingMessageID() == nil {
-		t.Error("expected NowPlayingMessageID to be set")
+	if state.GetNowPlayingMessage() == nil {
+		t.Error("expected NowPlayingMessage to be set")
 	}
 }
 
@@ -375,9 +375,10 @@ func TestNotificationEventHandler_PlaybackFinished_DeletesMessage(t *testing.T) 
 
 	repo := newMockRepository()
 	guildID := snowflake.ID(1)
+	channelID := snowflake.ID(200)
 	messageID := snowflake.ID(999)
-	state := domain.NewPlayerState(guildID, snowflake.ID(100), snowflake.ID(200))
-	state.SetNowPlayingMessageID(messageID)
+	state := domain.NewPlayerState(guildID, snowflake.ID(100), channelID)
+	state.SetNowPlayingMessage(channelID, messageID)
 	repo.Save(state)
 
 	notifier := &mockNotifier{}

--- a/internal/modules/music_player/application/usecases/playback.go
+++ b/internal/modules/music_player/application/usecases/playback.go
@@ -130,12 +130,12 @@ func (p *PlaybackService) Skip(ctx context.Context, input SkipInput) (*SkipOutpu
 	skippedTrack := state.CurrentTrack()
 
 	// Publish event to delete the "Now Playing" message
-	nowPlayingMsgID := state.GetNowPlayingMessageID()
-	if nowPlayingMsgID != nil && p.publisher != nil {
+	nowPlayingMsg := state.GetNowPlayingMessage()
+	if nowPlayingMsg != nil && p.publisher != nil {
 		p.publisher.PublishPlaybackFinished(ports.PlaybackFinishedEvent{
 			GuildID:               input.GuildID,
-			NotificationChannelID: state.NotificationChannelID,
-			LastMessageID:         nowPlayingMsgID,
+			NotificationChannelID: nowPlayingMsg.ChannelID,
+			LastMessageID:         &nowPlayingMsg.MessageID,
 		})
 	}
 

--- a/internal/modules/music_player/application/usecases/voice_channel.go
+++ b/internal/modules/music_player/application/usecases/voice_channel.go
@@ -110,12 +110,12 @@ func (v *VoiceChannelService) HandleBotVoiceStateChange(input BotVoiceStateChang
 	if input.NewChannelID == nil {
 		// Bot was disconnected from voice
 		// Publish event to delete the "Now Playing" message before we lose the state
-		nowPlayingMsgID := state.GetNowPlayingMessageID()
-		if nowPlayingMsgID != nil && v.publisher != nil {
+		nowPlayingMsg := state.GetNowPlayingMessage()
+		if nowPlayingMsg != nil && v.publisher != nil {
 			v.publisher.PublishPlaybackFinished(ports.PlaybackFinishedEvent{
 				GuildID:               input.GuildID,
-				NotificationChannelID: state.NotificationChannelID,
-				LastMessageID:         nowPlayingMsgID,
+				NotificationChannelID: nowPlayingMsg.ChannelID,
+				LastMessageID:         &nowPlayingMsg.MessageID,
 			})
 		}
 
@@ -138,12 +138,12 @@ func (v *VoiceChannelService) Leave(ctx context.Context, input LeaveInput) error
 	}
 
 	// Publish event to delete the "Now Playing" message before we lose the state
-	nowPlayingMsgID := state.GetNowPlayingMessageID()
-	if nowPlayingMsgID != nil && v.publisher != nil {
+	nowPlayingMsg := state.GetNowPlayingMessage()
+	if nowPlayingMsg != nil && v.publisher != nil {
 		v.publisher.PublishPlaybackFinished(ports.PlaybackFinishedEvent{
 			GuildID:               input.GuildID,
-			NotificationChannelID: state.NotificationChannelID,
-			LastMessageID:         nowPlayingMsgID,
+			NotificationChannelID: nowPlayingMsg.ChannelID,
+			LastMessageID:         &nowPlayingMsg.MessageID,
 		})
 	}
 

--- a/internal/modules/music_player/application/usecases/voice_channel_test.go
+++ b/internal/modules/music_player/application/usecases/voice_channel_test.go
@@ -329,7 +329,7 @@ func TestVoiceChannelService_Leave_PublishesPlaybackFinishedEvent(t *testing.T) 
 
 	// Create connected state with a now playing message
 	state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-	state.SetNowPlayingMessageID(nowPlayingMsgID)
+	state.SetNowPlayingMessage(notificationChannelID, nowPlayingMsgID)
 
 	service := NewVoiceChannelService(repo, connection, nil, publisher)
 
@@ -369,7 +369,7 @@ func TestVoiceChannelService_HandleBotVoiceStateChange_Disconnected(t *testing.T
 
 	// Create connected state with a now playing message
 	state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-	state.SetNowPlayingMessageID(nowPlayingMsgID)
+	state.SetNowPlayingMessage(notificationChannelID, nowPlayingMsgID)
 
 	service := NewVoiceChannelService(repo, nil, nil, publisher)
 


### PR DESCRIPTION
- Store the channel ID alongside message ID when sending "Now Playing" notifications.
- Previously, when users switched notification channels while a track was playing, the delete operation would fail because it attempted to delete the message from the new channel instead of the channel where it was originally sent.