### PR TITLE
ci: use job-level path filtering and add `status-check` job for required status checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,18 +3,29 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - ".golangci.yaml"
-      - ".github/workflows/ci.yaml"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  paths-filter:
+    name: Paths Filter
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - "**.go"
+              - "go.mod"
+              - "go.sum"
+              - ".golangci.yaml"
   lint:
     name: Lint
+    needs: paths-filter
+    if: needs.paths-filter.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -29,6 +40,8 @@ jobs:
           only-new-issues: true
   test:
     name: Test
+    needs: paths-filter
+    if: needs.paths-filter.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -41,6 +54,8 @@ jobs:
         run: go test -v -race ./...
   build-check:
     name: Build Check
+    needs: paths-filter
+    if: needs.paths-filter.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -51,3 +66,12 @@ jobs:
           go-version-file: "go.mod"
       - name: Build
         run: go build -v ./cmd/sgrbot
+  status-check:
+    name: Status Check
+    needs: [lint, test, build-check]
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - run: exit 1


### PR DESCRIPTION
- Replace workflow-level path filtering with job-level filtering using [dorny/paths-filter](https://github.com/dorny/paths-filter)
- Add aggregating `status-check` job as the single required status check
- Fixes issue where required checks stay "Pending" on PRs that do not change codes