### PR TITLE
feat(modules/music_player): switch from pop-based queue to index-based queue and support looping tracks

### DIFF
--- a/docs/modules/music-player.md
+++ b/docs/modules/music-player.md
@@ -26,7 +26,7 @@ Environment variables:
 | `/skip` | Skip to next track |
 | `/loop [mode]` | Set loop mode (none/track/queue) or cycle through modes |
 | `/queue list [page]` | Show queue with sections (Played/Now Playing/Up Next) |
-| `/queue remove <position>` | Remove track from queue (0 = current track, with autocomplete) |
+| `/queue remove <position>` | Remove track from queue (1-indexed position, with autocomplete) |
 | `/queue clear` | Clear queue (keeps current track) |
 
 ## Project Structure

--- a/internal/modules/music_player/application/events/handlers_test.go
+++ b/internal/modules/music_player/application/events/handlers_test.go
@@ -263,7 +263,7 @@ func TestPlaybackEventHandler_TrackEnded_LoadFailed_WithLoopModeTrack_AdvancesTo
 	handler.Start(t.Context())
 	defer handler.Stop()
 
-	// Publish track ended with "load_failed" reason
+	// Publish track ended with TrackEndLoadFailed reason
 	bus.PublishTrackEnded(TrackEndedEvent{
 		GuildID: guildID,
 		Reason:  TrackEndLoadFailed,

--- a/internal/modules/music_player/application/events/types.go
+++ b/internal/modules/music_player/application/events/types.go
@@ -11,6 +11,7 @@ type (
 	PlaybackFinishedEvent = ports.PlaybackFinishedEvent
 	TrackEndedEvent       = ports.TrackEndedEvent
 	TrackEndReason        = ports.TrackEndReason
+	QueueClearedEvent     = ports.QueueClearedEvent
 )
 
 // Re-export TrackEndReason constants.

--- a/internal/modules/music_player/application/ports/event_publisher.go
+++ b/internal/modules/music_player/application/ports/event_publisher.go
@@ -18,6 +18,9 @@ type EventPublisher interface {
 
 	// PublishTrackEnded publishes an event when a track ends (from audio player).
 	PublishTrackEnded(event TrackEndedEvent)
+
+	// PublishQueueCleared publishes an event when the queue is fully cleared.
+	PublishQueueCleared(event QueueClearedEvent)
 }
 
 // TrackEnqueuedEvent is published when a track is added to the queue.
@@ -46,6 +49,13 @@ type PlaybackFinishedEvent struct {
 type TrackEndedEvent struct {
 	GuildID snowflake.ID
 	Reason  TrackEndReason
+}
+
+// QueueClearedEvent is published when the queue is fully cleared (including current track).
+// This triggers playback to stop.
+type QueueClearedEvent struct {
+	GuildID               snowflake.ID
+	NotificationChannelID snowflake.ID
 }
 
 // TrackEndReason represents why a track ended.

--- a/internal/modules/music_player/application/usecases/errors.go
+++ b/internal/modules/music_player/application/usecases/errors.go
@@ -28,6 +28,10 @@ var (
 	// ErrInvalidPosition is returned when an invalid queue position is specified.
 	ErrInvalidPosition = errors.New("invalid queue position")
 
+	// ErrIsCurrentTrack is returned when trying to remove the currently playing track.
+	// The handler should delegate to Skip instead.
+	ErrIsCurrentTrack = errors.New("cannot remove current track, use skip instead")
+
 	// ErrLoadFailed is returned when loading tracks fails.
 	ErrLoadFailed = errors.New("failed to load track")
 )

--- a/internal/modules/music_player/application/usecases/errors.go
+++ b/internal/modules/music_player/application/usecases/errors.go
@@ -25,6 +25,9 @@ var (
 	// ErrQueueEmpty is returned when the queue is empty.
 	ErrQueueEmpty = errors.New("the queue is empty")
 
+	// ErrNothingToClear is returned when there are no tracks to clear (only current track exists).
+	ErrNothingToClear = errors.New("nothing to clear")
+
 	// ErrInvalidPosition is returned when an invalid queue position is specified.
 	ErrInvalidPosition = errors.New("invalid queue position")
 

--- a/internal/modules/music_player/application/usecases/playback.go
+++ b/internal/modules/music_player/application/usecases/playback.go
@@ -216,6 +216,9 @@ func (p *PlaybackService) PlayNext(
 
 	// Play via audio player
 	if err := p.audioPlayer.Play(ctx, guildID, nextTrack); err != nil {
+		// Reset to idle since playback failed to start.
+		// This prevents IsIdle() from returning false when nothing is actually playing.
+		state.Queue.ResetToIdle()
 		return nil, err
 	}
 

--- a/internal/modules/music_player/application/usecases/playback.go
+++ b/internal/modules/music_player/application/usecases/playback.go
@@ -35,7 +35,7 @@ type SkipOutput struct {
 // SetLoopModeInput contains the input for the SetLoopMode use case.
 type SetLoopModeInput struct {
 	GuildID               snowflake.ID
-	Mode                  domain.LoopMode
+	Mode                  string       // "none", "track", "queue"
 	NotificationChannelID snowflake.ID // Optional: updates notification channel if non-zero
 }
 
@@ -47,7 +47,7 @@ type CycleLoopModeInput struct {
 
 // CycleLoopModeOutput contains the result of the CycleLoopMode use case.
 type CycleLoopModeOutput struct {
-	NewMode domain.LoopMode
+	NewMode string // "none", "track", "queue"
 }
 
 // PlaybackService handles playback operations.
@@ -245,9 +245,21 @@ func (p *PlaybackService) SetLoopMode(ctx context.Context, input SetLoopModeInpu
 		state.SetNotificationChannel(input.NotificationChannelID)
 	}
 
-	state.SetLoopMode(input.Mode)
+	state.SetLoopMode(parseLoopMode(input.Mode))
 
 	return nil
+}
+
+// parseLoopMode converts a string to domain.LoopMode.
+func parseLoopMode(s string) domain.LoopMode {
+	switch s {
+	case "track":
+		return domain.LoopModeTrack
+	case "queue":
+		return domain.LoopModeQueue
+	default:
+		return domain.LoopModeNone
+	}
 }
 
 // CycleLoopMode cycles through loop modes: None -> Track -> Queue -> None.
@@ -268,6 +280,6 @@ func (p *PlaybackService) CycleLoopMode(
 	newMode := state.CycleLoopMode()
 
 	return &CycleLoopModeOutput{
-		NewMode: newMode,
+		NewMode: newMode.String(),
 	}, nil
 }

--- a/internal/modules/music_player/application/usecases/playback_test.go
+++ b/internal/modules/music_player/application/usecases/playback_test.go
@@ -308,6 +308,22 @@ func TestPlaybackService_Skip(t *testing.T) {
 			},
 			wantErr: errors.New("stop failed"),
 		},
+		{
+			name: "skip at last track with queue loop wraps to first",
+			input: SkipInput{
+				GuildID: guildID,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, textChannelID)
+				state.Queue.Add(mockTrack("first"))
+				state.Queue.Add(mockTrack("last"))
+				state.Queue.Start()                      // Start at first
+				state.Queue.Advance(domain.LoopModeNone) // Move to last
+				state.StartPlayback()
+				state.SetLoopMode(domain.LoopModeQueue)
+			},
+			wantNextTrack: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/modules/music_player/application/usecases/playback_test.go
+++ b/internal/modules/music_player/application/usecases/playback_test.go
@@ -218,8 +218,8 @@ func TestPlaybackService_Resume(t *testing.T) {
 
 			// Verify state was updated
 			state := repo.Get(guildID)
-			if !state.IsPlaying() {
-				t.Error("expected status to be playing")
+			if state.IsIdle() {
+				t.Error("expected playback to be active")
 			}
 		})
 	}
@@ -350,8 +350,8 @@ func TestPlaybackService_Skip(t *testing.T) {
 					t.Error("expected NextTrack to be set")
 				}
 				state := repo.Get(guildID)
-				if !state.IsPlaying() {
-					t.Error("expected status to be playing")
+				if state.IsIdle() {
+					t.Error("expected playback to be active")
 				}
 			} else {
 				if output.NextTrack != nil {
@@ -468,8 +468,8 @@ func TestPlaybackService_PlayNext(t *testing.T) {
 					t.Error("expected track to be set")
 				}
 				state := repo.Get(guildID)
-				if !state.IsPlaying() {
-					t.Error("expected status to be playing")
+				if state.IsIdle() {
+					t.Error("expected playback to be active")
 				}
 			} else {
 				if track != nil {
@@ -480,7 +480,7 @@ func TestPlaybackService_PlayNext(t *testing.T) {
 	}
 }
 
-func TestPlaybackService_PlayNext_ResetsQueueOnPlayFailure(t *testing.T) {
+func TestPlaybackService_PlayNext_PreservesQueuePositionOnPlayFailure(t *testing.T) {
 	guildID := snowflake.ID(1)
 	voiceChannelID := snowflake.ID(4)
 	textChannelID := snowflake.ID(3)
@@ -507,12 +507,13 @@ func TestPlaybackService_PlayNext_ResetsQueueOnPlayFailure(t *testing.T) {
 		return
 	}
 
-	// Verify queue is reset to idle after Play failure
-	if !state.Queue.IsIdle() {
-		t.Error("expected queue to be reset to idle after Play failure")
+	// Verify playback is marked as inactive but queue position is preserved
+	if !state.IsIdle() {
+		t.Error("expected playback to be inactive after Play failure")
 	}
-	if state.Queue.CurrentIndex() != -1 {
-		t.Errorf("expected currentIndex -1, got %d", state.Queue.CurrentIndex())
+	// Queue position should be preserved (index 0, not -1)
+	if state.Queue.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0 (preserved), got %d", state.Queue.CurrentIndex())
 	}
 }
 

--- a/internal/modules/music_player/application/usecases/playback_test.go
+++ b/internal/modules/music_player/application/usecases/playback_test.go
@@ -496,7 +496,7 @@ func TestPlaybackService_SetLoopMode(t *testing.T) {
 			name: "set loop mode to track",
 			input: SetLoopModeInput{
 				GuildID: guildID,
-				Mode:    domain.LoopModeTrack,
+				Mode:    "track",
 			},
 			setupRepo: func(m *mockRepository) {
 				m.createConnectedState(guildID, voiceChannelID, textChannelID)
@@ -507,7 +507,7 @@ func TestPlaybackService_SetLoopMode(t *testing.T) {
 			name: "set loop mode to queue",
 			input: SetLoopModeInput{
 				GuildID: guildID,
-				Mode:    domain.LoopModeQueue,
+				Mode:    "queue",
 			},
 			setupRepo: func(m *mockRepository) {
 				m.createConnectedState(guildID, voiceChannelID, textChannelID)
@@ -518,7 +518,7 @@ func TestPlaybackService_SetLoopMode(t *testing.T) {
 			name: "set loop mode to none",
 			input: SetLoopModeInput{
 				GuildID: guildID,
-				Mode:    domain.LoopModeNone,
+				Mode:    "none",
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, textChannelID)
@@ -530,7 +530,7 @@ func TestPlaybackService_SetLoopMode(t *testing.T) {
 			name: "not connected",
 			input: SetLoopModeInput{
 				GuildID: guildID,
-				Mode:    domain.LoopModeTrack,
+				Mode:    "track",
 			},
 			wantErr: ErrNotConnected,
 		},
@@ -577,12 +577,12 @@ func TestPlaybackService_CycleLoopMode(t *testing.T) {
 	textChannelID := snowflake.ID(3)
 
 	tests := []struct {
-		name        string
-		input       CycleLoopModeInput
-		setupRepo   func(*mockRepository)
-		wantErr     error
-		wantMode    domain.LoopMode
-		initialMode domain.LoopMode
+		name           string
+		input          CycleLoopModeInput
+		setupRepo      func(*mockRepository)
+		wantErr        error
+		wantModeStr    string          // expected output string
+		wantStateDMode domain.LoopMode // expected domain mode in state
 	}{
 		{
 			name: "cycle from none to track",
@@ -592,8 +592,8 @@ func TestPlaybackService_CycleLoopMode(t *testing.T) {
 			setupRepo: func(m *mockRepository) {
 				m.createConnectedState(guildID, voiceChannelID, textChannelID)
 			},
-			initialMode: domain.LoopModeNone,
-			wantMode:    domain.LoopModeTrack,
+			wantModeStr:    "track",
+			wantStateDMode: domain.LoopModeTrack,
 		},
 		{
 			name: "cycle from track to queue",
@@ -604,8 +604,8 @@ func TestPlaybackService_CycleLoopMode(t *testing.T) {
 				state := m.createConnectedState(guildID, voiceChannelID, textChannelID)
 				state.SetLoopMode(domain.LoopModeTrack)
 			},
-			initialMode: domain.LoopModeTrack,
-			wantMode:    domain.LoopModeQueue,
+			wantModeStr:    "queue",
+			wantStateDMode: domain.LoopModeQueue,
 		},
 		{
 			name: "cycle from queue to none",
@@ -616,8 +616,8 @@ func TestPlaybackService_CycleLoopMode(t *testing.T) {
 				state := m.createConnectedState(guildID, voiceChannelID, textChannelID)
 				state.SetLoopMode(domain.LoopModeQueue)
 			},
-			initialMode: domain.LoopModeQueue,
-			wantMode:    domain.LoopModeNone,
+			wantModeStr:    "none",
+			wantStateDMode: domain.LoopModeNone,
 		},
 		{
 			name: "not connected",
@@ -655,13 +655,13 @@ func TestPlaybackService_CycleLoopMode(t *testing.T) {
 				return
 			}
 
-			if output.NewMode != tt.wantMode {
-				t.Errorf("expected output mode %v, got %v", tt.wantMode, output.NewMode)
+			if output.NewMode != tt.wantModeStr {
+				t.Errorf("expected output mode %v, got %v", tt.wantModeStr, output.NewMode)
 			}
 
 			state := repo.Get(guildID)
-			if state.LoopMode() != tt.wantMode {
-				t.Errorf("expected state loop mode %v, got %v", tt.wantMode, state.LoopMode())
+			if state.LoopMode() != tt.wantStateDMode {
+				t.Errorf("expected state loop mode %v, got %v", tt.wantStateDMode, state.LoopMode())
 			}
 		})
 	}

--- a/internal/modules/music_player/application/usecases/queue.go
+++ b/internal/modules/music_player/application/usecases/queue.go
@@ -336,6 +336,18 @@ func (q *QueueService) Seek(
 		return nil, ErrInvalidPosition
 	}
 
+	// Delete the old "Now Playing" message before starting the new track
+	if q.publisher != nil {
+		nowPlayingMsg := state.GetNowPlayingMessage()
+		if nowPlayingMsg != nil {
+			q.publisher.PublishPlaybackFinished(ports.PlaybackFinishedEvent{
+				GuildID:               input.GuildID,
+				NotificationChannelID: nowPlayingMsg.ChannelID,
+				LastMessageID:         &nowPlayingMsg.MessageID,
+			})
+		}
+	}
+
 	// Seek to target position (sets currentIndex to position)
 	track := state.Queue.Seek(input.Position)
 

--- a/internal/modules/music_player/application/usecases/queue.go
+++ b/internal/modules/music_player/application/usecases/queue.go
@@ -37,8 +37,8 @@ type QueueListOutput struct {
 	TotalTracks  int             // Total tracks in queue
 	CurrentPage  int
 	TotalPages   int
-	PageStart    int             // 0-indexed start position of this page
-	LoopMode     domain.LoopMode // For display indicator
+	PageStart    int    // 0-indexed start position of this page
+	LoopMode     string // "none", "track", "queue"
 }
 
 // QueueRemoveInput contains the input for the QueueRemove use case.
@@ -175,7 +175,7 @@ func (q *QueueService) List(input QueueListInput) (*QueueListOutput, error) {
 		CurrentPage:  page,
 		TotalPages:   totalPages,
 		PageStart:    start,
-		LoopMode:     loopMode,
+		LoopMode:     loopMode.String(),
 	}, nil
 }
 

--- a/internal/modules/music_player/application/usecases/queue.go
+++ b/internal/modules/music_player/application/usecases/queue.go
@@ -349,6 +349,9 @@ func (q *QueueService) Seek(
 		}
 	}
 
+	// Mark playback as inactive so the event handler will trigger new playback
+	state.StopPlayback()
+
 	// Publish event to trigger playback.
 	// PlayNext will see currentIndex >= 0 (not idle) and play Current() directly,
 	// which is the track we just seeked to.

--- a/internal/modules/music_player/application/usecases/queue.go
+++ b/internal/modules/music_player/application/usecases/queue.go
@@ -331,8 +331,9 @@ func (q *QueueService) Seek(
 		return nil, ErrQueueEmpty
 	}
 
-	// Validate position
-	if input.Position < 0 || input.Position >= state.Queue.Len() {
+	// Seek to target position (atomic operation with bounds checking)
+	track := state.Queue.Seek(input.Position)
+	if track == nil {
 		return nil, ErrInvalidPosition
 	}
 
@@ -347,9 +348,6 @@ func (q *QueueService) Seek(
 			})
 		}
 	}
-
-	// Seek to target position (sets currentIndex to position)
-	track := state.Queue.Seek(input.Position)
 
 	// Publish event to trigger playback.
 	// PlayNext will see currentIndex >= 0 (not idle) and play Current() directly,

--- a/internal/modules/music_player/application/usecases/queue.go
+++ b/internal/modules/music_player/application/usecases/queue.go
@@ -243,7 +243,7 @@ func (q *QueueService) Clear(input QueueClearInput) (*QueueClearOutput, error) {
 		} else {
 			count = state.Queue.Len() - 1
 			if count == 0 {
-				return nil, ErrQueueEmpty // Nothing to clear besides current
+				return nil, ErrNothingToClear
 			}
 			// Use existing methods: clear all, add back current, start
 			state.Queue.Clear()

--- a/internal/modules/music_player/application/usecases/queue_test.go
+++ b/internal/modules/music_player/application/usecases/queue_test.go
@@ -13,14 +13,15 @@ func TestQueueService_List(t *testing.T) {
 	notificationChannelID := snowflake.ID(3)
 
 	tests := []struct {
-		name           string
-		input          QueueListInput
-		setupRepo      func(*mockRepository)
-		wantTotalTrack int // count of QUEUED tracks (excluding current)
-		wantPageTracks int // tracks on current page
-		wantPage       int
-		wantTotalPages int
-		wantCurrent    bool // expect current track to be set
+		name             string
+		input            QueueListInput
+		setupRepo        func(*mockRepository)
+		wantTotalTracks  int // total tracks in queue
+		wantPageTracks   int // tracks on current page
+		wantPage         int
+		wantTotalPages   int
+		wantCurrentIndex int // -1 if idle
+		wantPageStart    int // 0-indexed start position
 	}{
 		{
 			name: "empty queue",
@@ -31,30 +32,53 @@ func TestQueueService_List(t *testing.T) {
 			setupRepo: func(m *mockRepository) {
 				m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
 			},
-			wantTotalTrack: 0,
-			wantPageTracks: 0,
-			wantPage:       1,
-			wantTotalPages: 1,
-			wantCurrent:    false,
+			wantTotalTracks:  0,
+			wantPageTracks:   0,
+			wantPage:         1,
+			wantTotalPages:   1,
+			wantCurrentIndex: -1,
+			wantPageStart:    0,
 		},
 		{
-			name: "single page - only queued tracks (no current)",
+			name: "single page with tracks - idle (not started)",
 			input: QueueListInput{
 				GuildID: guildID,
 				Page:    1,
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				// Add 5 tracks - first becomes "current", rest are queued
+				// Add 5 tracks without starting playback
 				for i := range 5 {
 					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
 				}
 			},
-			wantTotalTrack: 4, // 5 total - 1 current = 4 queued
-			wantPageTracks: 4,
-			wantPage:       1,
-			wantTotalPages: 1,
-			wantCurrent:    true,
+			wantTotalTracks:  5,
+			wantPageTracks:   5,
+			wantPage:         1,
+			wantTotalPages:   1,
+			wantCurrentIndex: -1, // not started
+			wantPageStart:    0,
+		},
+		{
+			name: "single page with tracks - playing (started)",
+			input: QueueListInput{
+				GuildID: guildID,
+				Page:    1,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// Add 5 tracks and start playback
+				for i := range 5 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+			},
+			wantTotalTracks:  5,
+			wantPageTracks:   5,
+			wantPage:         1,
+			wantTotalPages:   1,
+			wantCurrentIndex: 0,
+			wantPageStart:    0,
 		},
 		{
 			name: "multiple pages - first page",
@@ -65,16 +89,18 @@ func TestQueueService_List(t *testing.T) {
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				// Add 8 tracks - first becomes "current", 7 are queued
+				// Add 8 tracks and start playback
 				for i := range 8 {
 					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
 				}
+				state.Queue.Start()
 			},
-			wantTotalTrack: 7, // 8 total - 1 current = 7 queued
-			wantPageTracks: 3,
-			wantPage:       1,
-			wantTotalPages: 3,
-			wantCurrent:    true,
+			wantTotalTracks:  8,
+			wantPageTracks:   3,
+			wantPage:         1,
+			wantTotalPages:   3,
+			wantCurrentIndex: 0,
+			wantPageStart:    0,
 		},
 		{
 			name: "multiple pages - last page",
@@ -85,16 +111,18 @@ func TestQueueService_List(t *testing.T) {
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				// Add 8 tracks - first becomes "current", 7 are queued
+				// Add 8 tracks and start playback
 				for i := range 8 {
 					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
 				}
+				state.Queue.Start()
 			},
-			wantTotalTrack: 7,
-			wantPageTracks: 1, // 7 queued, page 3 with size 3 = 1 track
-			wantPage:       3,
-			wantTotalPages: 3,
-			wantCurrent:    true,
+			wantTotalTracks:  8,
+			wantPageTracks:   2, // 8 tracks, page 3 with size 3 = tracks 6-7
+			wantPage:         3,
+			wantTotalPages:   3,
+			wantCurrentIndex: 0,
+			wantPageStart:    6,
 		},
 		{
 			name: "page out of range - clamp to last",
@@ -105,19 +133,45 @@ func TestQueueService_List(t *testing.T) {
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				// Add 5 tracks - first becomes "current", 4 are queued
+				// Add 5 tracks and start playback
 				for i := range 5 {
 					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
 				}
+				state.Queue.Start()
 			},
-			wantTotalTrack: 4,
-			wantPageTracks: 1, // 4 queued, page 2 (clamped) with size 3 = 1 track
-			wantPage:       2,
-			wantTotalPages: 2,
-			wantCurrent:    true,
+			wantTotalTracks:  5,
+			wantPageTracks:   2, // 5 tracks, page 2 (clamped) with size 3 = tracks 3-4
+			wantPage:         2,
+			wantTotalPages:   2,
+			wantCurrentIndex: 0,
+			wantPageStart:    3,
 		},
 		{
-			name: "with current track playing and queue",
+			name: "current track in middle of queue",
+			input: QueueListInput{
+				GuildID:  guildID,
+				Page:     1,
+				PageSize: 5,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// Add 5 tracks and advance to index 2
+				for i := range 5 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+				state.Queue.Advance(0)
+				state.Queue.Advance(0)
+			},
+			wantTotalTracks:  5,
+			wantPageTracks:   5,
+			wantPage:         1,
+			wantTotalPages:   1,
+			wantCurrentIndex: 2, // advanced twice from 0
+			wantPageStart:    0,
+		},
+		{
+			name: "with SetPlaying - prepends track",
 			input: QueueListInput{
 				GuildID: guildID,
 				Page:    1,
@@ -127,11 +181,58 @@ func TestQueueService_List(t *testing.T) {
 				state.SetPlaying(mockTrack("current"))
 				state.Queue.Add(mockTrack("queued"))
 			},
-			wantTotalTrack: 1, // 1 queued track
-			wantPageTracks: 1,
-			wantPage:       1,
-			wantTotalPages: 1,
-			wantCurrent:    true,
+			wantTotalTracks:  2, // current + queued
+			wantPageTracks:   2,
+			wantPage:         1,
+			wantTotalPages:   1,
+			wantCurrentIndex: 0,
+			wantPageStart:    0,
+		},
+		{
+			name: "default page - shows page containing current track",
+			input: QueueListInput{
+				GuildID:  guildID,
+				Page:     0, // No page specified
+				PageSize: 3,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// Add 10 tracks and advance to index 7 (page 3 with size 3)
+				for i := range 10 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+				for range 7 {
+					state.Queue.Advance(0)
+				}
+			},
+			wantTotalTracks:  10,
+			wantPageTracks:   3, // tracks 6, 7, 8 on page 3
+			wantPage:         3, // index 7 / pageSize 3 + 1 = page 3
+			wantTotalPages:   4,
+			wantCurrentIndex: 7,
+			wantPageStart:    6,
+		},
+		{
+			name: "default page - idle defaults to page 1",
+			input: QueueListInput{
+				GuildID:  guildID,
+				Page:     0, // No page specified
+				PageSize: 3,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// Add 10 tracks but don't start playback
+				for i := range 10 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+			},
+			wantTotalTracks:  10,
+			wantPageTracks:   3,
+			wantPage:         1, // idle defaults to page 1
+			wantTotalPages:   4,
+			wantCurrentIndex: -1,
+			wantPageStart:    0,
 		},
 	}
 
@@ -150,8 +251,8 @@ func TestQueueService_List(t *testing.T) {
 				return
 			}
 
-			if output.TotalTracks != tt.wantTotalTrack {
-				t.Errorf("TotalTracks = %d, want %d", output.TotalTracks, tt.wantTotalTrack)
+			if output.TotalTracks != tt.wantTotalTracks {
+				t.Errorf("TotalTracks = %d, want %d", output.TotalTracks, tt.wantTotalTracks)
 			}
 			if len(output.Tracks) != tt.wantPageTracks {
 				t.Errorf("len(Tracks) = %d, want %d", len(output.Tracks), tt.wantPageTracks)
@@ -162,11 +263,11 @@ func TestQueueService_List(t *testing.T) {
 			if output.TotalPages != tt.wantTotalPages {
 				t.Errorf("TotalPages = %d, want %d", output.TotalPages, tt.wantTotalPages)
 			}
-			if tt.wantCurrent && output.CurrentTrack == nil {
-				t.Error("expected CurrentTrack to be set")
+			if output.CurrentIndex != tt.wantCurrentIndex {
+				t.Errorf("CurrentIndex = %d, want %d", output.CurrentIndex, tt.wantCurrentIndex)
 			}
-			if !tt.wantCurrent && output.CurrentTrack != nil {
-				t.Error("expected CurrentTrack to be nil")
+			if output.PageStart != tt.wantPageStart {
+				t.Errorf("PageStart = %d, want %d", output.PageStart, tt.wantPageStart)
 			}
 		})
 	}
@@ -185,56 +286,47 @@ func TestQueueService_Remove(t *testing.T) {
 		wantID    string
 	}{
 		{
-			name: "remove from middle - position 2",
+			name: "remove upcoming track",
 			input: QueueRemoveInput{
 				GuildID:  guildID,
 				Position: 2,
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				// Queue: [0:current, 1:track-1, 2:track-2, 3:track-3]
+				// Queue: [0:current, 1:track-1, 2:track-2, 3:track-3], currentIndex=0
 				state.SetPlaying(mockTrack("current"))
 				state.Queue.Add(mockTrack("track-1"))
 				state.Queue.Add(mockTrack("track-2"))
 				state.Queue.Add(mockTrack("track-3"))
 			},
-			wantID: "track-2", // position 2
+			wantID: "track-2",
 		},
 		{
-			name: "remove first queued - position 1",
+			name: "remove played track (before current index)",
 			input: QueueRemoveInput{
 				GuildID:  guildID,
-				Position: 1,
+				Position: 0,
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				// Queue: [0:current, 1:track-1, 2:track-2]
-				state.SetPlaying(mockTrack("current"))
-				state.Queue.Add(mockTrack("track-1"))
-				state.Queue.Add(mockTrack("track-2"))
+				// Add tracks and advance to index 2
+				for i := range 5 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+				state.Queue.Advance(0)
+				state.Queue.Advance(0) // currentIndex=2
 			},
-			wantID: "track-1", // position 1
+			wantID: "track-0", // played track at index 0
 		},
 		{
-			name: "empty queue - no queued tracks",
+			name: "empty queue",
 			input: QueueRemoveInput{
 				GuildID:  guildID,
-				Position: 1,
+				Position: 0,
 			},
 			setupRepo: func(m *mockRepository) {
 				m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-			},
-			wantErr: ErrQueueEmpty,
-		},
-		{
-			name: "only current track - no queued tracks",
-			input: QueueRemoveInput{
-				GuildID:  guildID,
-				Position: 1,
-			},
-			setupRepo: func(m *mockRepository) {
-				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				state.SetPlaying(mockTrack("current"))
 			},
 			wantErr: ErrQueueEmpty,
 		},
@@ -252,17 +344,36 @@ func TestQueueService_Remove(t *testing.T) {
 			wantErr: ErrInvalidPosition,
 		},
 		{
-			name: "position zero - should be handled by Skip at handler level",
+			name: "remove current track - returns ErrIsCurrentTrack",
 			input: QueueRemoveInput{
 				GuildID:  guildID,
 				Position: 0,
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// currentIndex=0 after SetPlaying
 				state.SetPlaying(mockTrack("current"))
 				state.Queue.Add(mockTrack("track-1"))
 			},
-			wantErr: ErrInvalidPosition,
+			wantErr: ErrIsCurrentTrack,
+		},
+		{
+			name: "remove current track after advancing - returns ErrIsCurrentTrack",
+			input: QueueRemoveInput{
+				GuildID:  guildID,
+				Position: 2,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// Add tracks and advance to index 2
+				for i := range 5 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+				state.Queue.Advance(0)
+				state.Queue.Advance(0) // currentIndex=2
+			},
+			wantErr: ErrIsCurrentTrack,
 		},
 		{
 			name: "invalid position - negative",
@@ -413,32 +524,68 @@ func TestQueueService_Clear(t *testing.T) {
 		setupRepo     func(*mockRepository)
 		wantErr       error
 		wantCount     int
-		wantRemaining int // tracks remaining after clear (should be 1 = current)
+		wantRemaining int
 	}{
 		{
-			name: "clear queue - keeps current track",
+			name: "KeepCurrentTrack=true - clears played and upcoming, keeps only current",
 			input: QueueClearInput{
-				GuildID: guildID,
+				GuildID:          guildID,
+				KeepCurrentTrack: true,
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
-				state.SetPlaying(mockTrack("current"))
-				state.Queue.Add(mockTrack("track-1"))
-				state.Queue.Add(mockTrack("track-2"))
-				state.Queue.Add(mockTrack("track-3"))
+				// Add 5 tracks and advance to index 2 (track-2 is current)
+				for i := range 5 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+				state.Queue.Advance(0)
+				state.Queue.Advance(0) // currentIndex=2
 			},
-			wantCount:     3, // 3 queued tracks cleared
-			wantRemaining: 1, // current track remains
+			wantCount:     4, // 2 played + 2 upcoming cleared
+			wantRemaining: 1, // only current track remains
 		},
 		{
-			name: "empty queue - only current track",
+			name: "KeepCurrentTrack=true - only current track, nothing to clear",
 			input: QueueClearInput{
-				GuildID: guildID,
+				GuildID:          guildID,
+				KeepCurrentTrack: true,
 			},
 			setupRepo: func(m *mockRepository) {
 				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
 				state.SetPlaying(mockTrack("current"))
-				// No queued tracks
+				// No other tracks
+			},
+			wantErr: ErrQueueEmpty,
+		},
+		{
+			name: "KeepCurrentTrack=false - clears all tracks",
+			input: QueueClearInput{
+				GuildID:          guildID,
+				KeepCurrentTrack: false,
+			},
+			setupRepo: func(m *mockRepository) {
+				state := m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// Add 5 tracks and advance to index 2
+				for i := range 5 {
+					state.Queue.Add(mockTrack("track-" + string(rune('0'+i))))
+				}
+				state.Queue.Start()
+				state.Queue.Advance(0)
+				state.Queue.Advance(0)
+			},
+			wantCount:     5, // all 5 tracks cleared
+			wantRemaining: 0, // nothing remains
+		},
+		{
+			name: "KeepCurrentTrack=false - empty queue",
+			input: QueueClearInput{
+				GuildID:          guildID,
+				KeepCurrentTrack: false,
+			},
+			setupRepo: func(m *mockRepository) {
+				m.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+				// No tracks
 			},
 			wantErr: ErrQueueEmpty,
 		},
@@ -489,4 +636,73 @@ func TestQueueService_Clear(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestQueueService_Clear_PublishesQueueClearedEvent(t *testing.T) {
+	guildID := snowflake.ID(1)
+	voiceChannelID := snowflake.ID(4)
+	notificationChannelID := snowflake.ID(3)
+
+	t.Run("KeepCurrentTrack=false publishes QueueClearedEvent", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+
+		state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+		state.Queue.Add(mockTrack("track-1"))
+		state.Queue.Add(mockTrack("track-2"))
+		state.Queue.Start()
+
+		service := NewQueueService(repo, publisher)
+		_, err := service.Clear(QueueClearInput{
+			GuildID:               guildID,
+			NotificationChannelID: notificationChannelID,
+			KeepCurrentTrack:      false,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify QueueClearedEvent was published
+		if len(publisher.queueCleared) != 1 {
+			t.Fatalf("expected 1 QueueClearedEvent, got %d", len(publisher.queueCleared))
+		}
+
+		event := publisher.queueCleared[0]
+		if event.GuildID != guildID {
+			t.Errorf("event GuildID = %d, want %d", event.GuildID, guildID)
+		}
+		if event.NotificationChannelID != notificationChannelID {
+			t.Errorf(
+				"event NotificationChannelID = %d, want %d",
+				event.NotificationChannelID,
+				notificationChannelID,
+			)
+		}
+	})
+
+	t.Run("KeepCurrentTrack=true does not publish QueueClearedEvent", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+
+		state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+		state.Queue.Add(mockTrack("track-1"))
+		state.Queue.Add(mockTrack("track-2"))
+		state.Queue.Add(mockTrack("track-3"))
+		state.Queue.Start()
+
+		service := NewQueueService(repo, publisher)
+		_, err := service.Clear(QueueClearInput{
+			GuildID:               guildID,
+			NotificationChannelID: notificationChannelID,
+			KeepCurrentTrack:      true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify QueueClearedEvent was NOT published
+		if len(publisher.queueCleared) != 0 {
+			t.Errorf("expected 0 QueueClearedEvents, got %d", len(publisher.queueCleared))
+		}
+	})
 }

--- a/internal/modules/music_player/application/usecases/queue_test.go
+++ b/internal/modules/music_player/application/usecases/queue_test.go
@@ -787,11 +787,11 @@ func TestQueueService_Restart(t *testing.T) {
 				t.Errorf("event WasIdle = %v, want %v", event.WasIdle, tt.wantWasIdle)
 			}
 
-			// Verify queue was reset to idle
+			// Verify queue is at position 0 (Restart uses Seek(0))
 			state := repo.Get(guildID)
-			if state.Queue.CurrentIndex() != -1 {
+			if state.Queue.CurrentIndex() != 0 {
 				t.Errorf(
-					"expected currentIndex -1 after Restart, got %d",
+					"expected currentIndex 0 after Restart, got %d",
 					state.Queue.CurrentIndex(),
 				)
 			}

--- a/internal/modules/music_player/application/usecases/queue_test.go
+++ b/internal/modules/music_player/application/usecases/queue_test.go
@@ -556,7 +556,7 @@ func TestQueueService_Clear(t *testing.T) {
 				state.SetPlaying(mockTrack("current"))
 				// No other tracks
 			},
-			wantErr: ErrQueueEmpty,
+			wantErr: ErrNothingToClear,
 		},
 		{
 			name: "KeepCurrentTrack=true - idle state with played tracks clears all",

--- a/internal/modules/music_player/application/usecases/test_helpers_test.go
+++ b/internal/modules/music_player/application/usecases/test_helpers_test.go
@@ -121,6 +121,7 @@ type mockEventPublisher struct {
 	playbackStarted  []ports.PlaybackStartedEvent
 	playbackFinished []ports.PlaybackFinishedEvent
 	trackEnded       []ports.TrackEndedEvent
+	queueCleared     []ports.QueueClearedEvent
 }
 
 func (m *mockEventPublisher) PublishTrackEnqueued(event ports.TrackEnqueuedEvent) {
@@ -137,4 +138,8 @@ func (m *mockEventPublisher) PublishPlaybackFinished(event ports.PlaybackFinishe
 
 func (m *mockEventPublisher) PublishTrackEnded(event ports.TrackEndedEvent) {
 	m.trackEnded = append(m.trackEnded, event)
+}
+
+func (m *mockEventPublisher) PublishQueueCleared(event ports.QueueClearedEvent) {
+	m.queueCleared = append(m.queueCleared, event)
 }

--- a/internal/modules/music_player/domain/loop_mode.go
+++ b/internal/modules/music_player/domain/loop_mode.go
@@ -1,0 +1,22 @@
+package domain
+
+// LoopMode represents the loop mode for queue playback.
+type LoopMode int
+
+const (
+	LoopModeNone  LoopMode = iota // Default: no looping
+	LoopModeTrack                 // Repeat current track indefinitely
+	LoopModeQueue                 // Repeat entire queue when reaching end
+)
+
+// String returns a human-readable representation of the loop mode.
+func (m LoopMode) String() string {
+	switch m {
+	case LoopModeTrack:
+		return "track"
+	case LoopModeQueue:
+		return "queue"
+	default:
+		return "none"
+	}
+}

--- a/internal/modules/music_player/domain/loop_mode_test.go
+++ b/internal/modules/music_player/domain/loop_mode_test.go
@@ -1,0 +1,53 @@
+package domain
+
+import "testing"
+
+func TestLoopMode_String(t *testing.T) {
+	tests := []struct {
+		name string
+		mode LoopMode
+		want string
+	}{
+		{
+			name: "LoopModeNone returns none",
+			mode: LoopModeNone,
+			want: "none",
+		},
+		{
+			name: "LoopModeTrack returns track",
+			mode: LoopModeTrack,
+			want: "track",
+		},
+		{
+			name: "LoopModeQueue returns queue",
+			mode: LoopModeQueue,
+			want: "queue",
+		},
+		{
+			name: "unknown mode returns none",
+			mode: LoopMode(99),
+			want: "none",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.mode.String(); got != tt.want {
+				t.Errorf("LoopMode.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoopMode_IotaValues(t *testing.T) {
+	// Verify iota values are as expected
+	if LoopModeNone != 0 {
+		t.Errorf("LoopModeNone = %d, want 0", LoopModeNone)
+	}
+	if LoopModeTrack != 1 {
+		t.Errorf("LoopModeTrack = %d, want 1", LoopModeTrack)
+	}
+	if LoopModeQueue != 2 {
+		t.Errorf("LoopModeQueue = %d, want 2", LoopModeQueue)
+	}
+}

--- a/internal/modules/music_player/domain/player_state.go
+++ b/internal/modules/music_player/domain/player_state.go
@@ -20,7 +20,8 @@ type PlayerState struct {
 	GuildID               snowflake.ID
 	VoiceChannelID        snowflake.ID       // Voice channel the bot is connected to
 	NotificationChannelID snowflake.ID       // Text channel for notifications
-	paused                bool               // unexported to prevent direct access
+	playbackActive        bool               // true when audio player is engaged (playing or paused)
+	paused                bool               // true when playback is paused
 	loopMode              LoopMode           // loop mode for playback
 	Queue                 *Queue             // Queue with index-based track management
 	nowPlayingMessage     *NowPlayingMessage // "Now Playing" message info (for deletion)
@@ -37,23 +38,19 @@ func NewPlayerState(guildID, voiceChannelID, notificationChannelID snowflake.ID)
 	}
 }
 
-// IsIdle returns true if no track is currently active (queue not started or past end).
+// IsIdle returns true if playback is not active (audio player not engaged).
+// This is independent of queue position - a track can be selected but not playing.
 func (p *PlayerState) IsIdle() bool {
-	return p.Queue.IsIdle()
-}
-
-// IsPlaying returns true if a track is currently playing (not paused).
-func (p *PlayerState) IsPlaying() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return !p.Queue.IsIdle() && !p.paused
+	return !p.playbackActive
 }
 
 // IsPaused returns true if playback is paused.
 func (p *PlayerState) IsPaused() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return !p.Queue.IsIdle() && p.paused
+	return p.playbackActive && p.paused
 }
 
 // CurrentTrack returns the currently playing track.
@@ -82,11 +79,29 @@ func (p *PlayerState) SetNotificationChannel(channelID snowflake.ID) {
 	p.NotificationChannelID = channelID
 }
 
-// SetPlaying sets the current track (prepends to queue) and clears the paused state.
+// SetPlaying sets the current track (prepends to queue) and starts playback.
 func (p *PlayerState) SetPlaying(track *Track) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.Queue.Prepend(track)
+	p.playbackActive = true
+	p.paused = false
+}
+
+// StartPlayback marks playback as active. Called when Play() succeeds.
+func (p *PlayerState) StartPlayback() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playbackActive = true
+	p.paused = false
+}
+
+// StopPlayback marks playback as inactive without changing queue position.
+// Called when Play() fails or playback ends.
+func (p *PlayerState) StopPlayback() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playbackActive = false
 	p.paused = false
 }
 
@@ -94,7 +109,7 @@ func (p *PlayerState) SetPlaying(track *Track) {
 func (p *PlayerState) SetPaused() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !p.Queue.IsIdle() {
+	if p.playbackActive {
 		p.paused = true
 	}
 }
@@ -103,16 +118,17 @@ func (p *PlayerState) SetPaused() {
 func (p *PlayerState) SetResumed() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !p.Queue.IsIdle() {
+	if p.playbackActive {
 		p.paused = false
 	}
 }
 
-// SetStopped advances the queue based on the current loop mode and clears the paused state.
+// SetStopped advances the queue based on the current loop mode and stops playback.
 func (p *PlayerState) SetStopped() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.Queue.Advance(p.loopMode)
+	p.playbackActive = false
 	p.paused = false
 }
 

--- a/internal/modules/music_player/domain/player_state.go
+++ b/internal/modules/music_player/domain/player_state.go
@@ -97,12 +97,13 @@ func (p *PlayerState) StartPlayback() {
 }
 
 // StopPlayback marks playback as inactive without changing queue position.
-// Called when Play() fails or playback ends.
+// Called when Play() fails or playback ends. Also resets loop mode to none.
 func (p *PlayerState) StopPlayback() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.playbackActive = false
 	p.paused = false
+	p.loopMode = LoopModeNone
 }
 
 // SetPaused sets the paused state to true.

--- a/internal/modules/music_player/domain/player_state_test.go
+++ b/internal/modules/music_player/domain/player_state_test.go
@@ -47,36 +47,27 @@ func TestNewPlayerState(t *testing.T) {
 func TestPlayerState_StatusMethods(t *testing.T) {
 	state := newTestPlayerState()
 
-	// Initial state is idle
+	// Initial state is idle (playbackActive=false)
 	if !state.IsIdle() {
 		t.Error("new state should be idle")
-	}
-	if state.IsPlaying() {
-		t.Error("new state should not be playing")
 	}
 	if state.IsPaused() {
 		t.Error("new state should not be paused")
 	}
 
-	// Set playing
+	// Set playing (playbackActive=true, paused=false)
 	state.SetPlaying(&Track{ID: "track-1"})
 	if state.IsIdle() {
 		t.Error("playing state should not be idle")
-	}
-	if !state.IsPlaying() {
-		t.Error("playing state should be playing")
 	}
 	if state.IsPaused() {
 		t.Error("playing state should not be paused")
 	}
 
-	// Set paused
+	// Set paused (playbackActive=true, paused=true)
 	state.SetPaused()
 	if state.IsIdle() {
 		t.Error("paused state should not be idle")
-	}
-	if state.IsPlaying() {
-		t.Error("paused state should not be playing")
 	}
 	if !state.IsPaused() {
 		t.Error("paused state should be paused")
@@ -121,8 +112,8 @@ func TestPlayerState_SetPlaying(t *testing.T) {
 	if state.IsPaused() {
 		t.Error("expected not to be paused")
 	}
-	if !state.IsPlaying() {
-		t.Error("expected IsPlaying to return true")
+	if state.IsIdle() {
+		t.Error("expected playback to be active")
 	}
 }
 
@@ -161,8 +152,8 @@ func TestPlayerState_SetResumed(t *testing.T) {
 	if state.IsPaused() {
 		t.Error("expected not to be paused")
 	}
-	if !state.IsPlaying() {
-		t.Error("expected IsPlaying to return true")
+	if state.IsIdle() {
+		t.Error("expected playback to be active")
 	}
 }
 
@@ -360,7 +351,7 @@ func TestPlayerState_ConcurrentAccess(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			_ = state.IsPlaying()
+			_ = state.IsIdle()
 		}()
 
 		go func() {

--- a/internal/modules/music_player/domain/player_state_test.go
+++ b/internal/modules/music_player/domain/player_state_test.go
@@ -175,6 +175,25 @@ func TestPlayerState_SetStopped(t *testing.T) {
 	}
 }
 
+func TestPlayerState_StopPlayback_ResetsLoopMode(t *testing.T) {
+	state := newTestPlayerState()
+	state.SetPlaying(&Track{ID: "track-1"})
+	state.SetLoopMode(LoopModeQueue)
+
+	if state.LoopMode() != LoopModeQueue {
+		t.Error("expected loop mode to be queue")
+	}
+
+	state.StopPlayback()
+
+	if state.LoopMode() != LoopModeNone {
+		t.Error("expected loop mode to be reset to none after StopPlayback")
+	}
+	if !state.IsIdle() {
+		t.Error("expected IsIdle to return true")
+	}
+}
+
 func TestPlayerState_HasTrack(t *testing.T) {
 	state := newTestPlayerState()
 

--- a/internal/modules/music_player/domain/player_state_test.go
+++ b/internal/modules/music_player/domain/player_state_test.go
@@ -237,11 +237,114 @@ func TestPlayerState_TotalTracks(t *testing.T) {
 		t.Errorf("expected 3, got %d", got)
 	}
 
-	// Stop (remove current track)
+	// Stop advances to next track but keeps all tracks (index-based model)
 	state.SetStopped()
-	if got := state.TotalTracks(); got != 2 {
-		t.Errorf("expected 2, got %d", got)
+	if got := state.TotalTracks(); got != 3 {
+		t.Errorf("expected 3 (tracks kept in queue), got %d", got)
 	}
+}
+
+func TestPlayerState_LoopMode(t *testing.T) {
+	state := newTestPlayerState()
+
+	// Default loop mode is None
+	if got := state.LoopMode(); got != LoopModeNone {
+		t.Errorf("expected LoopModeNone, got %v", got)
+	}
+
+	// Set loop mode
+	state.SetLoopMode(LoopModeTrack)
+	if got := state.LoopMode(); got != LoopModeTrack {
+		t.Errorf("expected LoopModeTrack, got %v", got)
+	}
+
+	state.SetLoopMode(LoopModeQueue)
+	if got := state.LoopMode(); got != LoopModeQueue {
+		t.Errorf("expected LoopModeQueue, got %v", got)
+	}
+}
+
+func TestPlayerState_CycleLoopMode(t *testing.T) {
+	state := newTestPlayerState()
+
+	// None -> Track
+	got := state.CycleLoopMode()
+	if got != LoopModeTrack {
+		t.Errorf("expected LoopModeTrack, got %v", got)
+	}
+	if state.LoopMode() != LoopModeTrack {
+		t.Error("state loop mode should be updated")
+	}
+
+	// Track -> Queue
+	got = state.CycleLoopMode()
+	if got != LoopModeQueue {
+		t.Errorf("expected LoopModeQueue, got %v", got)
+	}
+
+	// Queue -> None
+	got = state.CycleLoopMode()
+	if got != LoopModeNone {
+		t.Errorf("expected LoopModeNone, got %v", got)
+	}
+}
+
+func TestPlayerState_SetStopped_WithLoopModes(t *testing.T) {
+	t.Run("LoopModeNone advances to next track", func(t *testing.T) {
+		state := newTestPlayerState()
+		track1 := &Track{ID: "track-1"}
+		track2 := &Track{ID: "track-2"}
+
+		state.Queue.Add(track1)
+		state.Queue.Add(track2)
+		state.Queue.Start()
+
+		state.SetStopped()
+
+		if state.CurrentTrack() != track2 {
+			t.Error("expected current track to be track2")
+		}
+	})
+
+	t.Run("LoopModeTrack replays same track", func(t *testing.T) {
+		state := newTestPlayerState()
+		track1 := &Track{ID: "track-1"}
+		track2 := &Track{ID: "track-2"}
+
+		state.Queue.Add(track1)
+		state.Queue.Add(track2)
+		state.Queue.Start()
+		state.SetLoopMode(LoopModeTrack)
+
+		state.SetStopped()
+
+		if state.CurrentTrack() != track1 {
+			t.Error("expected current track to still be track1")
+		}
+	})
+
+	t.Run("LoopModeQueue wraps to start", func(t *testing.T) {
+		state := newTestPlayerState()
+		track1 := &Track{ID: "track-1"}
+		track2 := &Track{ID: "track-2"}
+
+		state.Queue.Add(track1)
+		state.Queue.Add(track2)
+		state.Queue.Start()
+		state.SetLoopMode(LoopModeQueue)
+
+		// Advance to track2
+		state.SetStopped()
+		if state.CurrentTrack() != track2 {
+			t.Error("expected current track to be track2")
+		}
+
+		// Should wrap to track1
+		state.SetStopped()
+		if state.CurrentTrack() != track1 {
+			t.Error("expected current track to wrap to track1")
+		}
+	})
 }
 
 func TestPlayerState_ConcurrentAccess(t *testing.T) {

--- a/internal/modules/music_player/domain/queue.go
+++ b/internal/modules/music_player/domain/queue.go
@@ -254,3 +254,18 @@ func (q *Queue) ResetToIdle() {
 	defer q.mu.Unlock()
 	q.currentIndex = -1
 }
+
+// Seek sets the currentIndex to the specified position (0-indexed).
+// Returns the track at that position, or nil if position is out of bounds.
+// Does not change currentIndex if position is invalid.
+func (q *Queue) Seek(position int) *Track {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if position < 0 || position >= len(q.tracks) {
+		return nil
+	}
+
+	q.currentIndex = position
+	return q.tracks[position]
+}

--- a/internal/modules/music_player/domain/queue.go
+++ b/internal/modules/music_player/domain/queue.go
@@ -246,3 +246,11 @@ func (q *Queue) ClearAfterCurrent() int {
 	q.tracks = q.tracks[:q.currentIndex+1]
 	return count
 }
+
+// ResetToIdle resets the queue to idle state (before first track).
+// Used when playback fails to start or when restarting the queue.
+func (q *Queue) ResetToIdle() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.currentIndex = -1
+}

--- a/internal/modules/music_player/domain/queue.go
+++ b/internal/modules/music_player/domain/queue.go
@@ -102,13 +102,14 @@ func (q *Queue) HasNext(mode LoopMode) bool {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 
-	if len(q.tracks) == 0 || q.currentIndex < 0 {
+	// No next if queue is empty or idle (not started or past end)
+	if len(q.tracks) == 0 || q.currentIndex < 0 || q.currentIndex >= len(q.tracks) {
 		return false
 	}
 
 	switch mode {
 	case LoopModeTrack, LoopModeQueue:
-		// Always has next when looping (as long as queue isn't empty)
+		// Always has next when looping (as long as queue isn't empty and not idle)
 		return true
 	default: // LoopModeNone
 		return q.currentIndex+1 < len(q.tracks)

--- a/internal/modules/music_player/domain/queue.go
+++ b/internal/modules/music_player/domain/queue.go
@@ -2,59 +2,145 @@ package domain
 
 import "sync"
 
-// Queue is a thread-safe queue for managing tracks.
+// Queue is a thread-safe queue for managing tracks using an index-based model.
+// Instead of removing tracks when they finish, we maintain a currentIndex
+// that advances through the track list, enabling loop functionality.
 type Queue struct {
-	mu     sync.RWMutex
-	tracks []*Track
+	mu           sync.RWMutex
+	tracks       []*Track
+	currentIndex int // -1 when empty or before first track, 0+ when playing
 }
 
 // NewQueue creates a new empty Queue.
 func NewQueue() *Queue {
 	return &Queue{
-		tracks: make([]*Track, 0),
+		tracks:       make([]*Track, 0),
+		currentIndex: -1,
 	}
 }
 
 // Add adds a track to the end of the queue.
-// Returns true if the queue was empty before adding (to trigger auto-play).
-func (q *Queue) Add(track *Track) (wasEmpty bool) {
+// Returns true if the player was idle (no current track), to trigger auto-play.
+func (q *Queue) Add(track *Track) (wasIdle bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	wasEmpty = len(q.tracks) == 0
+	wasIdle = q.currentIndex < 0 || q.currentIndex >= len(q.tracks)
 	q.tracks = append(q.tracks, track)
-	return wasEmpty
+	return wasIdle
 }
 
-// Next removes and returns the first track from the queue.
-// Returns nil if the queue is empty.
-func (q *Queue) Next() *Track {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	if len(q.tracks) == 0 {
-		return nil
-	}
-
-	track := q.tracks[0]
-	q.tracks = q.tracks[1:]
-	return track
-}
-
-// Peek returns the first track without removing it.
-// Returns nil if the queue is empty.
-func (q *Queue) Peek() *Track {
+// Current returns the track at currentIndex, or nil if no current track.
+func (q *Queue) Current() *Track {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
 
+	if q.currentIndex < 0 || q.currentIndex >= len(q.tracks) {
+		return nil
+	}
+	return q.tracks[q.currentIndex]
+}
+
+// Peek returns the current track without changing position.
+// This is an alias for Current() for backward compatibility.
+func (q *Queue) Peek() *Track {
+	return q.Current()
+}
+
+// Start sets currentIndex to 0 if the queue has tracks.
+// Returns the first track, or nil if queue is empty.
+// Used when playback should begin from the start.
+func (q *Queue) Start() *Track {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
 	if len(q.tracks) == 0 {
 		return nil
 	}
+	q.currentIndex = 0
 	return q.tracks[0]
+}
+
+// Advance moves to the next track based on loop mode.
+// Returns the new current track, or nil if queue ended.
+//   - LoopModeNone: advance index, return nil if past end
+//   - LoopModeTrack: don't advance, return same track
+//   - LoopModeQueue: advance, wrap to 0 if past end
+func (q *Queue) Advance(mode LoopMode) *Track {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.tracks) == 0 || q.currentIndex < 0 {
+		return nil
+	}
+
+	switch mode {
+	case LoopModeTrack:
+		// Don't advance, return same track
+		return q.tracks[q.currentIndex]
+
+	case LoopModeQueue:
+		// Advance with wrap-around
+		q.currentIndex++
+		if q.currentIndex >= len(q.tracks) {
+			q.currentIndex = 0
+		}
+		return q.tracks[q.currentIndex]
+
+	default: // LoopModeNone
+		// Advance without wrap
+		q.currentIndex++
+		if q.currentIndex >= len(q.tracks) {
+			return nil
+		}
+		return q.tracks[q.currentIndex]
+	}
+}
+
+// HasNext returns true if there's a next track available (considering loop mode).
+func (q *Queue) HasNext(mode LoopMode) bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	if len(q.tracks) == 0 || q.currentIndex < 0 {
+		return false
+	}
+
+	switch mode {
+	case LoopModeTrack, LoopModeQueue:
+		// Always has next when looping (as long as queue isn't empty)
+		return true
+	default: // LoopModeNone
+		return q.currentIndex+1 < len(q.tracks)
+	}
+}
+
+// Upcoming returns tracks after the current index (for queue display).
+// Returns empty slice if no tracks or no current track.
+func (q *Queue) Upcoming() []*Track {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	if q.currentIndex < 0 || q.currentIndex >= len(q.tracks)-1 {
+		return make([]*Track, 0)
+	}
+
+	upcoming := q.tracks[q.currentIndex+1:]
+	result := make([]*Track, len(upcoming))
+	copy(result, upcoming)
+	return result
+}
+
+// CurrentIndex returns the current track index (-1 if not started or empty).
+func (q *Queue) CurrentIndex() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.currentIndex
 }
 
 // RemoveAt removes and returns the track at the given index (0-indexed).
 // Returns nil if the index is out of bounds.
+// Adjusts currentIndex if removing a track before the current position.
 func (q *Queue) RemoveAt(index int) *Track {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -65,10 +151,23 @@ func (q *Queue) RemoveAt(index int) *Track {
 
 	track := q.tracks[index]
 	q.tracks = append(q.tracks[:index], q.tracks[index+1:]...)
+
+	// Adjust currentIndex if we removed a track before or at current position
+	if index < q.currentIndex {
+		q.currentIndex--
+	} else if index == q.currentIndex {
+		// Removed current track; index now points to the next track (or past end)
+		// Keep index as-is; caller should handle this case
+		if q.currentIndex >= len(q.tracks) && len(q.tracks) > 0 {
+			// If we removed the last track and there are still tracks, adjust
+			q.currentIndex = len(q.tracks) - 1
+		}
+	}
+
 	return track
 }
 
-// Clear removes all tracks from the queue.
+// Clear removes all tracks from the queue and resets the index.
 // Returns the number of tracks that were removed.
 func (q *Queue) Clear() int {
 	q.mu.Lock()
@@ -76,6 +175,7 @@ func (q *Queue) Clear() int {
 
 	count := len(q.tracks)
 	q.tracks = make([]*Track, 0)
+	q.currentIndex = -1
 	return count
 }
 
@@ -89,7 +189,7 @@ func (q *Queue) List() []*Track {
 	return result
 }
 
-// Len returns the number of tracks in the queue.
+// Len returns the total number of tracks in the queue.
 func (q *Queue) Len() int {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -100,6 +200,13 @@ func (q *Queue) Len() int {
 // IsEmpty returns true if the queue has no tracks.
 func (q *Queue) IsEmpty() bool {
 	return q.Len() == 0
+}
+
+// IsIdle returns true if there is no current track (not started or past end).
+func (q *Queue) IsIdle() bool {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return q.currentIndex < 0 || q.currentIndex >= len(q.tracks)
 }
 
 // GetAt returns the track at the given index without removing it.
@@ -114,25 +221,27 @@ func (q *Queue) GetAt(index int) *Track {
 	return q.tracks[index]
 }
 
-// Prepend adds a track to the front of the queue (index 0).
+// Prepend adds a track to the front of the queue (index 0) and sets currentIndex to 0.
+// This is used when starting playback of a new track immediately.
 func (q *Queue) Prepend(track *Track) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	q.tracks = append([]*Track{track}, q.tracks...)
+	q.currentIndex = 0
 }
 
-// ClearAfterCurrent removes all tracks except index 0.
+// ClearAfterCurrent removes all tracks after the current track.
 // Returns the number of tracks removed.
 func (q *Queue) ClearAfterCurrent() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	if len(q.tracks) <= 1 {
+	if q.currentIndex < 0 || q.currentIndex >= len(q.tracks)-1 {
 		return 0
 	}
 
-	count := len(q.tracks) - 1
-	q.tracks = q.tracks[:1]
+	count := len(q.tracks) - q.currentIndex - 1
+	q.tracks = q.tracks[:q.currentIndex+1]
 	return count
 }

--- a/internal/modules/music_player/domain/queue_test.go
+++ b/internal/modules/music_player/domain/queue_test.go
@@ -15,6 +15,9 @@ func TestNewQueue(t *testing.T) {
 	if q.Len() != 0 {
 		t.Errorf("expected empty queue, got length %d", q.Len())
 	}
+	if q.CurrentIndex() != -1 {
+		t.Errorf("expected currentIndex -1, got %d", q.CurrentIndex())
+	}
 }
 
 func TestQueue_Add(t *testing.T) {
@@ -22,81 +25,292 @@ func TestQueue_Add(t *testing.T) {
 	track1 := &Track{ID: "track-1", Title: "Song 1"}
 	track2 := &Track{ID: "track-2", Title: "Song 2"}
 
-	// First add to empty queue should return wasEmpty=true
-	wasEmpty := q.Add(track1)
-	if !wasEmpty {
-		t.Error("expected wasEmpty=true for first add")
+	// First add to idle queue should return wasIdle=true
+	wasIdle := q.Add(track1)
+	if !wasIdle {
+		t.Error("expected wasIdle=true for first add")
 	}
 	if q.Len() != 1 {
 		t.Errorf("expected length 1, got %d", q.Len())
 	}
 
-	// Second add should return wasEmpty=false
-	wasEmpty = q.Add(track2)
-	if wasEmpty {
-		t.Error("expected wasEmpty=false for second add")
+	// Start playback
+	q.Start()
+
+	// Second add while playing should return wasIdle=false
+	wasIdle = q.Add(track2)
+	if wasIdle {
+		t.Error("expected wasIdle=false when playing")
 	}
 	if q.Len() != 2 {
 		t.Errorf("expected length 2, got %d", q.Len())
 	}
 }
 
-func TestQueue_Next(t *testing.T) {
+func TestQueue_Add_WasIdleAfterQueueEnds(t *testing.T) {
 	q := NewQueue()
 	track1 := &Track{ID: "track-1", Title: "Song 1"}
 	track2 := &Track{ID: "track-2", Title: "Song 2"}
 
-	// Next on empty queue returns nil
-	if got := q.Next(); got != nil {
-		t.Errorf("expected nil from empty queue, got %v", got)
-	}
-
 	q.Add(track1)
-	q.Add(track2)
+	q.Start()
 
-	// Next should return first track
-	got := q.Next()
-	if got != track1 {
-		t.Errorf("expected track1, got %v", got)
-	}
-	if q.Len() != 1 {
-		t.Errorf("expected length 1 after Next, got %d", q.Len())
-	}
+	// Advance past the end
+	q.Advance(LoopModeNone)
 
-	// Next should return second track
-	got = q.Next()
-	if got != track2 {
-		t.Errorf("expected track2, got %v", got)
-	}
-	if q.Len() != 0 {
-		t.Errorf("expected length 0 after second Next, got %d", q.Len())
+	// Adding now should return wasIdle=true since we're past the end
+	wasIdle := q.Add(track2)
+	if !wasIdle {
+		t.Error("expected wasIdle=true after queue ended")
 	}
 }
 
-func TestQueue_Peek(t *testing.T) {
+func TestQueue_Current(t *testing.T) {
 	q := NewQueue()
 	track := &Track{ID: "track-1", Title: "Song 1"}
 
-	// Peek on empty queue returns nil
-	if got := q.Peek(); got != nil {
+	// Current on empty queue returns nil
+	if got := q.Current(); got != nil {
 		t.Errorf("expected nil from empty queue, got %v", got)
 	}
 
 	q.Add(track)
 
-	// Peek should return first track without removing
-	got := q.Peek()
+	// Current before Start returns nil (currentIndex is -1)
+	if got := q.Current(); got != nil {
+		t.Errorf("expected nil before Start, got %v", got)
+	}
+
+	// After Start, Current returns the first track
+	q.Start()
+	if got := q.Current(); got != track {
+		t.Errorf("expected track after Start, got %v", got)
+	}
+}
+
+func TestQueue_Peek_AliasForCurrent(t *testing.T) {
+	q := NewQueue()
+	track := &Track{ID: "track-1", Title: "Song 1"}
+
+	q.Add(track)
+	q.Start()
+
+	// Peek should return same as Current
+	if q.Peek() != q.Current() {
+		t.Error("Peek should be an alias for Current")
+	}
+}
+
+func TestQueue_Start(t *testing.T) {
+	q := NewQueue()
+	track := &Track{ID: "track-1", Title: "Song 1"}
+
+	// Start on empty queue returns nil
+	if got := q.Start(); got != nil {
+		t.Errorf("expected nil from empty queue, got %v", got)
+	}
+	if q.CurrentIndex() != -1 {
+		t.Errorf("expected currentIndex -1 after Start on empty, got %d", q.CurrentIndex())
+	}
+
+	q.Add(track)
+
+	// Start should return first track and set index to 0
+	got := q.Start()
 	if got != track {
 		t.Errorf("expected track, got %v", got)
 	}
-	if q.Len() != 1 {
-		t.Errorf("expected length 1 after Peek, got %d", q.Len())
+	if q.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0, got %d", q.CurrentIndex())
+	}
+}
+
+func TestQueue_Advance_LoopModeNone(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+
+	// Advance on empty queue returns nil
+	if got := q.Advance(LoopModeNone); got != nil {
+		t.Errorf("expected nil from empty queue, got %v", got)
 	}
 
-	// Peek again should return same track
-	got = q.Peek()
-	if got != track {
-		t.Errorf("expected same track on second Peek, got %v", got)
+	q.Add(track1)
+	q.Add(track2)
+	q.Start()
+
+	// Advance should return next track
+	got := q.Advance(LoopModeNone)
+	if got != track2 {
+		t.Errorf("expected track2, got %v", got)
+	}
+	if q.CurrentIndex() != 1 {
+		t.Errorf("expected currentIndex 1, got %d", q.CurrentIndex())
+	}
+
+	// Advance past end should return nil
+	got = q.Advance(LoopModeNone)
+	if got != nil {
+		t.Errorf("expected nil past end, got %v", got)
+	}
+
+	// Tracks should still be in queue
+	if q.Len() != 2 {
+		t.Errorf("expected 2 tracks still in queue, got %d", q.Len())
+	}
+}
+
+func TestQueue_Advance_LoopModeTrack(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Start()
+
+	// Advance with LoopModeTrack should return same track
+	got := q.Advance(LoopModeTrack)
+	if got != track1 {
+		t.Errorf("expected track1, got %v", got)
+	}
+	if q.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0, got %d", q.CurrentIndex())
+	}
+
+	// Multiple advances should keep returning same track
+	for i := 0; i < 5; i++ {
+		got = q.Advance(LoopModeTrack)
+		if got != track1 {
+			t.Errorf("iteration %d: expected track1, got %v", i, got)
+		}
+	}
+}
+
+func TestQueue_Advance_LoopModeQueue(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+	track3 := &Track{ID: "track-3", Title: "Song 3"}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Add(track3)
+	q.Start()
+
+	// Advance through all tracks
+	if got := q.Advance(LoopModeQueue); got != track2 {
+		t.Errorf("expected track2, got %v", got)
+	}
+	if got := q.Advance(LoopModeQueue); got != track3 {
+		t.Errorf("expected track3, got %v", got)
+	}
+
+	// Should wrap to beginning
+	got := q.Advance(LoopModeQueue)
+	if got != track1 {
+		t.Errorf("expected track1 (wrap), got %v", got)
+	}
+	if q.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0 after wrap, got %d", q.CurrentIndex())
+	}
+}
+
+func TestQueue_Advance_LoopModeQueue_SingleTrack(t *testing.T) {
+	q := NewQueue()
+	track := &Track{ID: "track-1", Title: "Song 1"}
+
+	q.Add(track)
+	q.Start()
+
+	// Single track with LoopModeQueue should keep returning same track
+	for i := 0; i < 5; i++ {
+		got := q.Advance(LoopModeQueue)
+		if got != track {
+			t.Errorf("iteration %d: expected track, got %v", i, got)
+		}
+	}
+}
+
+func TestQueue_HasNext(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+
+	// HasNext on empty queue returns false
+	if q.HasNext(LoopModeNone) {
+		t.Error("expected HasNext=false for empty queue")
+	}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Start()
+
+	// HasNext with LoopModeNone should be true when there are more tracks
+	if !q.HasNext(LoopModeNone) {
+		t.Error("expected HasNext=true with more tracks")
+	}
+
+	// Advance to last track
+	q.Advance(LoopModeNone)
+
+	// HasNext should be false at last track with LoopModeNone
+	if q.HasNext(LoopModeNone) {
+		t.Error("expected HasNext=false at last track with LoopModeNone")
+	}
+
+	// HasNext should be true with LoopModeTrack
+	if !q.HasNext(LoopModeTrack) {
+		t.Error("expected HasNext=true with LoopModeTrack")
+	}
+
+	// HasNext should be true with LoopModeQueue
+	if !q.HasNext(LoopModeQueue) {
+		t.Error("expected HasNext=true with LoopModeQueue")
+	}
+}
+
+func TestQueue_Upcoming(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+	track3 := &Track{ID: "track-3", Title: "Song 3"}
+
+	// Upcoming on empty queue returns empty slice
+	upcoming := q.Upcoming()
+	if len(upcoming) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(upcoming))
+	}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Add(track3)
+	q.Start()
+
+	// Upcoming should return tracks after current
+	upcoming = q.Upcoming()
+	if len(upcoming) != 2 {
+		t.Errorf("expected 2 upcoming, got %d", len(upcoming))
+	}
+	if upcoming[0] != track2 || upcoming[1] != track3 {
+		t.Error("unexpected upcoming track order")
+	}
+
+	// Advance and check upcoming again
+	q.Advance(LoopModeNone)
+	upcoming = q.Upcoming()
+	if len(upcoming) != 1 {
+		t.Errorf("expected 1 upcoming, got %d", len(upcoming))
+	}
+	if upcoming[0] != track3 {
+		t.Error("expected track3 as upcoming")
+	}
+
+	// At last track, upcoming should be empty
+	q.Advance(LoopModeNone)
+	upcoming = q.Upcoming()
+	if len(upcoming) != 0 {
+		t.Errorf("expected empty upcoming at last track, got %d", len(upcoming))
 	}
 }
 
@@ -109,20 +323,21 @@ func TestQueue_RemoveAt(t *testing.T) {
 	q.Add(track1)
 	q.Add(track2)
 	q.Add(track3)
+	q.Start()
 
-	// Remove middle track
-	removed := q.RemoveAt(1)
-	if removed != track2 {
-		t.Errorf("expected track2, got %v", removed)
-	}
-	if q.Len() != 2 {
-		t.Errorf("expected length 2, got %d", q.Len())
-	}
+	// Set current to track2 (index 1)
+	q.Advance(LoopModeNone)
 
-	// Verify order
-	list := q.List()
-	if list[0] != track1 || list[1] != track3 {
-		t.Error("unexpected track order after RemoveAt")
+	// Remove track before current (should decrement currentIndex)
+	removed := q.RemoveAt(0)
+	if removed != track1 {
+		t.Errorf("expected track1, got %v", removed)
+	}
+	if q.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0 after removing before, got %d", q.CurrentIndex())
+	}
+	if q.Current() != track2 {
+		t.Error("current track should still be track2")
 	}
 
 	// Remove at invalid index returns nil
@@ -134,6 +349,55 @@ func TestQueue_RemoveAt(t *testing.T) {
 	}
 }
 
+func TestQueue_RemoveAt_CurrentTrack(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Start()
+
+	// Remove current track
+	removed := q.RemoveAt(0)
+	if removed != track1 {
+		t.Errorf("expected track1, got %v", removed)
+	}
+
+	// Current should now be track2
+	if q.Current() != track2 {
+		t.Error("current track should be track2 after removing track1")
+	}
+	if q.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0, got %d", q.CurrentIndex())
+	}
+}
+
+func TestQueue_RemoveAt_AdjustsIndexWhenRemovingLastTrack(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Start()
+	q.Advance(LoopModeNone) // Now at track2 (index 1)
+
+	// Remove current track (which is the last one)
+	removed := q.RemoveAt(1)
+	if removed != track2 {
+		t.Errorf("expected track2, got %v", removed)
+	}
+
+	// Index should be adjusted to point to last available track
+	if q.CurrentIndex() != 0 {
+		t.Errorf("expected currentIndex 0 after removing last, got %d", q.CurrentIndex())
+	}
+	if q.Current() != track1 {
+		t.Error("current track should be track1")
+	}
+}
+
 func TestQueue_Clear(t *testing.T) {
 	q := NewQueue()
 	track1 := &Track{ID: "track-1", Title: "Song 1"}
@@ -141,6 +405,7 @@ func TestQueue_Clear(t *testing.T) {
 
 	q.Add(track1)
 	q.Add(track2)
+	q.Start()
 
 	count := q.Clear()
 	if count != 2 {
@@ -148,6 +413,9 @@ func TestQueue_Clear(t *testing.T) {
 	}
 	if q.Len() != 0 {
 		t.Errorf("expected empty queue after Clear, got length %d", q.Len())
+	}
+	if q.CurrentIndex() != -1 {
+		t.Errorf("expected currentIndex -1 after Clear, got %d", q.CurrentIndex())
 	}
 
 	// Clear empty queue returns 0
@@ -181,7 +449,8 @@ func TestQueue_List(t *testing.T) {
 
 	// Verify List returns a copy (modifying it doesn't affect queue)
 	list[0] = nil
-	if q.Peek() != track1 {
+	q.Start()
+	if q.Current() != track1 {
 		t.Error("modifying List result affected queue")
 	}
 }
@@ -198,9 +467,40 @@ func TestQueue_IsEmpty(t *testing.T) {
 		t.Error("queue with track should not be empty")
 	}
 
-	q.Next()
+	q.Clear()
 	if !q.IsEmpty() {
-		t.Error("queue should be empty after removing only track")
+		t.Error("queue should be empty after Clear")
+	}
+}
+
+func TestQueue_IsIdle(t *testing.T) {
+	q := NewQueue()
+
+	// Empty queue is idle
+	if !q.IsIdle() {
+		t.Error("empty queue should be idle")
+	}
+
+	q.Add(&Track{ID: "track-1"})
+
+	// Queue with tracks but not started is idle
+	if !q.IsIdle() {
+		t.Error("queue before Start should be idle")
+	}
+
+	q.Start()
+
+	// After Start, not idle
+	if q.IsIdle() {
+		t.Error("queue after Start should not be idle")
+	}
+
+	// Advance past end
+	q.Advance(LoopModeNone)
+
+	// Past end is idle
+	if !q.IsIdle() {
+		t.Error("queue past end should be idle")
 	}
 }
 
@@ -231,6 +531,35 @@ func TestQueue_GetAt(t *testing.T) {
 	}
 }
 
+func TestQueue_ClearAfterCurrent(t *testing.T) {
+	q := NewQueue()
+	track1 := &Track{ID: "track-1", Title: "Song 1"}
+	track2 := &Track{ID: "track-2", Title: "Song 2"}
+	track3 := &Track{ID: "track-3", Title: "Song 3"}
+
+	q.Add(track1)
+	q.Add(track2)
+	q.Add(track3)
+	q.Start()
+
+	count := q.ClearAfterCurrent()
+	if count != 2 {
+		t.Errorf("expected 2 tracks removed, got %d", count)
+	}
+	if q.Len() != 1 {
+		t.Errorf("expected 1 track remaining, got %d", q.Len())
+	}
+	if q.Current() != track1 {
+		t.Error("current track should still be track1")
+	}
+
+	// ClearAfterCurrent when already at last track returns 0
+	count = q.ClearAfterCurrent()
+	if count != 0 {
+		t.Errorf("expected 0 tracks removed, got %d", count)
+	}
+}
+
 func TestQueue_ConcurrentAccess(t *testing.T) {
 	q := NewQueue()
 	var wg sync.WaitGroup
@@ -249,7 +578,9 @@ func TestQueue_ConcurrentAccess(t *testing.T) {
 		wg.Go(func() {
 			q.Len()
 			q.List()
-			q.Peek()
+			q.Current()
+			q.CurrentIndex()
+			q.IsIdle()
 		})
 	}
 
@@ -257,5 +588,39 @@ func TestQueue_ConcurrentAccess(t *testing.T) {
 
 	if q.Len() != 100 {
 		t.Errorf("expected 100 tracks after concurrent adds, got %d", q.Len())
+	}
+}
+
+func TestQueue_ConcurrentAdvance(t *testing.T) {
+	q := NewQueue()
+
+	// Add tracks
+	for i := range 100 {
+		q.Add(&Track{ID: TrackID(strconv.Itoa(i))})
+	}
+	q.Start()
+
+	var wg sync.WaitGroup
+
+	// Concurrent advances and reads
+	for range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			q.Advance(LoopModeNone)
+		}()
+		go func() {
+			defer wg.Done()
+			q.Current()
+			q.HasNext(LoopModeNone)
+		}()
+	}
+
+	wg.Wait()
+
+	// Should not panic and index should be valid
+	idx := q.CurrentIndex()
+	if idx < 0 || idx > 100 {
+		t.Errorf("unexpected currentIndex %d after concurrent operations", idx)
 	}
 }

--- a/internal/modules/music_player/module.go
+++ b/internal/modules/music_player/module.go
@@ -241,8 +241,13 @@ func (m *MusicPlayerModule) handleInteractionCreate(
 	case "play":
 		m.autocomplete.HandlePlay(s, i)
 	case "queue":
-		if len(data.Options) > 0 && data.Options[0].Name == "remove" {
-			m.autocomplete.HandleQueueRemove(s, i)
+		if len(data.Options) > 0 {
+			switch data.Options[0].Name {
+			case "remove":
+				m.autocomplete.HandleQueueRemove(s, i)
+			case "seek":
+				m.autocomplete.HandleQueueSeek(s, i)
+			}
 		}
 	}
 }

--- a/internal/modules/music_player/module.go
+++ b/internal/modules/music_player/module.go
@@ -60,6 +60,7 @@ func (m *MusicPlayerModule) CommandHandlers() map[string]bot.InteractionHandler 
 		"resume": m.handlers.HandleResume,
 		"skip":   m.handlers.HandleSkip,
 		"queue":  m.handlers.HandleQueue,
+		"loop":   m.handlers.HandleLoop,
 	}
 }
 
@@ -145,7 +146,12 @@ func (m *MusicPlayerModule) initWithLavalink(deps bot.ModuleDependencies) error 
 	trackLoader := usecases.NewTrackLoaderService(lavalinkAdapter)
 
 	// Create event handlers
-	m.playbackHandler = events.NewPlaybackEventHandler(playback.PlayNext, repo, m.eventBus)
+	m.playbackHandler = events.NewPlaybackEventHandler(
+		playback.PlayNext,
+		lavalinkAdapter.Stop,
+		repo,
+		m.eventBus,
+	)
 	m.notificationHandler = events.NewNotificationEventHandler(notifier, repo, m.eventBus)
 
 	// Start event handlers with cancellable context

--- a/internal/modules/music_player/presentation/autocomplete.go
+++ b/internal/modules/music_player/presentation/autocomplete.go
@@ -53,9 +53,11 @@ func (h *AutocompleteHandler) HandleQueueRemove(
 		if idx >= 25 {
 			break
 		}
+		// Use 1-indexed positions to match queue list display
+		displayPos := idx + 1
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-			Name:  fmt.Sprintf("%d. %s", idx, truncate(track.Title, 90)),
-			Value: idx,
+			Name:  fmt.Sprintf("%d. %s", displayPos, truncate(track.Title, 90)),
+			Value: displayPos,
 		})
 	}
 

--- a/internal/modules/music_player/presentation/autocomplete.go
+++ b/internal/modules/music_player/presentation/autocomplete.go
@@ -29,6 +29,22 @@ func (h *AutocompleteHandler) HandleQueueRemove(
 	s *discordgo.Session,
 	i *discordgo.InteractionCreate,
 ) {
+	h.handleQueuePositionAutocomplete(s, i)
+}
+
+// HandleQueueSeek handles autocomplete for queue seek command.
+func (h *AutocompleteHandler) HandleQueueSeek(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+) {
+	h.handleQueuePositionAutocomplete(s, i)
+}
+
+// handleQueuePositionAutocomplete is a shared helper for queue position autocomplete.
+func (h *AutocompleteHandler) handleQueuePositionAutocomplete(
+	s *discordgo.Session,
+	i *discordgo.InteractionCreate,
+) {
 	guildID, err := snowflake.Parse(i.GuildID)
 	if err != nil {
 		slog.Warn("failed to parse guild ID in autocomplete", "error", err, "guildID", i.GuildID)

--- a/internal/modules/music_player/presentation/commands.go
+++ b/internal/modules/music_player/presentation/commands.go
@@ -94,6 +94,23 @@ func Commands() []*discordgo.ApplicationCommand {
 				},
 			},
 		},
+		{
+			Name:        "loop",
+			Description: "Set the loop mode (or cycle through modes if no option provided)",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "mode",
+					Description: "Loop mode to set (omit to cycle through modes)",
+					Required:    false,
+					Choices: []*discordgo.ApplicationCommandOptionChoice{
+						{Name: "Off", Value: "none"},
+						{Name: "Track", Value: "track"},
+						{Name: "Queue", Value: "queue"},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/modules/music_player/presentation/commands.go
+++ b/internal/modules/music_player/presentation/commands.go
@@ -97,6 +97,21 @@ func Commands() []*discordgo.ApplicationCommand {
 					Name:        "restart",
 					Description: "Restart the queue from the beginning",
 				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "seek",
+					Description: "Jump to a specific position in the queue",
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:         discordgo.ApplicationCommandOptionInteger,
+							Name:         "position",
+							Description:  "Position to jump to (1-indexed, as shown in queue list)",
+							Required:     true,
+							MinValue:     floatPtr(1),
+							Autocomplete: true,
+						},
+					},
+				},
 			},
 		},
 		{

--- a/internal/modules/music_player/presentation/commands.go
+++ b/internal/modules/music_player/presentation/commands.go
@@ -92,6 +92,11 @@ func Commands() []*discordgo.ApplicationCommand {
 					Name:        "clear",
 					Description: "Clear the queue",
 				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "restart",
+					Description: "Restart the queue from the beginning",
+				},
 			},
 		},
 		{

--- a/internal/modules/music_player/presentation/commands.go
+++ b/internal/modules/music_player/presentation/commands.go
@@ -80,9 +80,9 @@ func Commands() []*discordgo.ApplicationCommand {
 						{
 							Type:         discordgo.ApplicationCommandOptionInteger,
 							Name:         "position",
-							Description:  "Position of the track to remove (0 = current track)",
+							Description:  "Position of the track to remove (1-indexed, as shown in queue list)",
 							Required:     true,
-							MinValue:     floatPtr(0),
+							MinValue:     floatPtr(1),
 							Autocomplete: true,
 						},
 					},

--- a/internal/modules/music_player/presentation/handlers.go
+++ b/internal/modules/music_player/presentation/handlers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/sglre6355/sgrbot/internal/bot"
 	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/usecases"
-	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
 )
 
 // Embed colors.
@@ -471,19 +470,18 @@ func (h *Handlers) HandleLoop(
 		}
 	}
 
-	var newMode domain.LoopMode
+	var newMode string
 	if modeStr != "" {
 		// Set specific mode
-		mode := parseLoopMode(modeStr)
 		err := h.playback.SetLoopMode(ctx, usecases.SetLoopModeInput{
 			GuildID:               guildID,
-			Mode:                  mode,
+			Mode:                  modeStr,
 			NotificationChannelID: notificationChannelID,
 		})
 		if err != nil {
 			return respondError(r, err.Error())
 		}
-		newMode = mode
+		newMode = modeStr
 	} else {
 		// Cycle through modes
 		output, err := h.playback.CycleLoopMode(ctx, usecases.CycleLoopModeInput{
@@ -497,17 +495,6 @@ func (h *Handlers) HandleLoop(
 	}
 
 	return respondLoopModeChanged(r, newMode)
-}
-
-func parseLoopMode(s string) domain.LoopMode {
-	switch s {
-	case "track":
-		return domain.LoopModeTrack
-	case "queue":
-		return domain.LoopModeQueue
-	default:
-		return domain.LoopModeNone
-	}
 }
 
 // Response helpers.
@@ -653,12 +640,12 @@ func respondQueueCleared(r bot.Responder) error {
 	})
 }
 
-func respondLoopModeChanged(r bot.Responder, mode domain.LoopMode) error {
+func respondLoopModeChanged(r bot.Responder, mode string) error {
 	var description string
 	switch mode {
-	case domain.LoopModeTrack:
+	case "track":
 		description = "Now looping the current track."
-	case domain.LoopModeQueue:
+	case "queue":
 		description = "Now looping the queue."
 	default:
 		description = "Loop disabled."
@@ -702,9 +689,9 @@ func respondQueueList(r bot.Responder, output *usecases.QueueListOutput) error {
 	// Build title with loop mode indicator
 	title := "Queue"
 	switch output.LoopMode {
-	case domain.LoopModeTrack:
+	case "track":
 		title = "Queue \U0001F502" // 🔂
-	case domain.LoopModeQueue:
+	case "queue":
 		title = "Queue \U0001F501" // 🔁
 	}
 


### PR DESCRIPTION
- Switch from pop-based queue, which drops tracks once finished playing, to index-based queue, which preserves tracks and only modifies queue index.
- Add `/loop` command that can cycle through or specify loop modes (`LoopModeNone`, `LoopModeTrack`, `LoopModeQueue`).