### PR TITLE
feat(modules/music_player): add playlist support to `play` command

### DIFF
--- a/internal/modules/music_player/application/usecases/autocomplete_test.go
+++ b/internal/modules/music_player/application/usecases/autocomplete_test.go
@@ -1,0 +1,245 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/ports"
+)
+
+func TestAutocompleteService_LoadTracksForAutocomplete(t *testing.T) {
+	singleTrackResult := &ports.LoadResult{
+		Type: ports.LoadTypeTrack,
+		Tracks: []*ports.TrackInfo{
+			{Identifier: "track-1", Title: "Single Track", Artist: "Artist"},
+		},
+	}
+
+	searchResult := &ports.LoadResult{
+		Type: ports.LoadTypeSearch,
+		Tracks: []*ports.TrackInfo{
+			{Identifier: "search-1", Title: "Search Result 1"},
+			{Identifier: "search-2", Title: "Search Result 2"},
+			{Identifier: "search-3", Title: "Search Result 3"},
+		},
+	}
+
+	playlistResult := &ports.LoadResult{
+		Type:       ports.LoadTypePlaylist,
+		PlaylistID: "My Playlist",
+		Tracks: []*ports.TrackInfo{
+			{Identifier: "pl-1", Title: "Playlist Track 1"},
+			{Identifier: "pl-2", Title: "Playlist Track 2"},
+			{Identifier: "pl-3", Title: "Playlist Track 3"},
+			{Identifier: "pl-4", Title: "Playlist Track 4"},
+			{Identifier: "pl-5", Title: "Playlist Track 5"},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		input            LoadTracksForAutocompleteInput
+		setupResolver    func(*mockTrackResolver)
+		wantIsPlaylist   bool
+		wantPlaylistName string
+		wantPlaylistURL  string
+		wantTrackCount   int
+		wantTracksLen    int
+		wantErr          bool
+	}{
+		{
+			name: "single track result",
+			input: LoadTracksForAutocompleteInput{
+				Query: "https://youtube.com/watch?v=123",
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadResult = singleTrackResult
+			},
+			wantIsPlaylist:   false,
+			wantPlaylistName: "",
+			wantTrackCount:   1,
+			wantTracksLen:    1,
+		},
+		{
+			name: "search result",
+			input: LoadTracksForAutocompleteInput{
+				Query: "search query",
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadResult = searchResult
+			},
+			wantIsPlaylist:   false,
+			wantPlaylistName: "",
+			wantTrackCount:   3,
+			wantTracksLen:    3,
+		},
+		{
+			name: "playlist result",
+			input: LoadTracksForAutocompleteInput{
+				Query: "https://youtube.com/playlist?list=abc",
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadResult = playlistResult
+			},
+			wantIsPlaylist:   true,
+			wantPlaylistName: "My Playlist",
+			wantPlaylistURL:  "https://youtube.com/playlist?list=abc",
+			wantTrackCount:   5,
+			wantTracksLen:    5,
+		},
+		{
+			name: "playlist result with limit",
+			input: LoadTracksForAutocompleteInput{
+				Query: "https://youtube.com/playlist?list=abc",
+				Limit: 2,
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadResult = playlistResult
+			},
+			wantIsPlaylist:   true,
+			wantPlaylistName: "My Playlist",
+			wantPlaylistURL:  "https://youtube.com/playlist?list=abc",
+			wantTrackCount:   5, // Total tracks in playlist
+			wantTracksLen:    2, // Limited to 2
+		},
+		{
+			name: "empty result",
+			input: LoadTracksForAutocompleteInput{
+				Query: "nonexistent",
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadResult = &ports.LoadResult{Type: ports.LoadTypeEmpty}
+			},
+			wantIsPlaylist: false,
+			wantTrackCount: 0,
+			wantTracksLen:  0,
+		},
+		{
+			name: "error result",
+			input: LoadTracksForAutocompleteInput{
+				Query: "error",
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadResult = &ports.LoadResult{Type: ports.LoadTypeError}
+			},
+			wantIsPlaylist: false,
+			wantTrackCount: 0,
+			wantTracksLen:  0,
+		},
+		{
+			name: "resolver error",
+			input: LoadTracksForAutocompleteInput{
+				Query: "test",
+			},
+			setupResolver: func(m *mockTrackResolver) {
+				m.loadErr = errors.New("connection failed")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &mockTrackResolver{}
+			if tt.setupResolver != nil {
+				tt.setupResolver(resolver)
+			}
+
+			service := NewAutocompleteService(nil, resolver)
+			output, err := service.LoadTracksForAutocomplete(context.Background(), tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if output.IsPlaylist != tt.wantIsPlaylist {
+				t.Errorf("IsPlaylist = %v, want %v", output.IsPlaylist, tt.wantIsPlaylist)
+			}
+
+			if output.PlaylistName != tt.wantPlaylistName {
+				t.Errorf("PlaylistName = %q, want %q", output.PlaylistName, tt.wantPlaylistName)
+			}
+
+			if tt.wantPlaylistURL != "" && output.PlaylistURL != tt.wantPlaylistURL {
+				t.Errorf("PlaylistURL = %q, want %q", output.PlaylistURL, tt.wantPlaylistURL)
+			}
+
+			if output.TrackCount != tt.wantTrackCount {
+				t.Errorf("TrackCount = %d, want %d", output.TrackCount, tt.wantTrackCount)
+			}
+
+			if len(output.Tracks) != tt.wantTracksLen {
+				t.Errorf("len(Tracks) = %d, want %d", len(output.Tracks), tt.wantTracksLen)
+			}
+		})
+	}
+}
+
+func TestAutocompleteService_LoadTracksForAutocomplete_NilResolver(t *testing.T) {
+	service := NewAutocompleteService(nil, nil)
+	output, err := service.LoadTracksForAutocomplete(
+		context.Background(),
+		LoadTracksForAutocompleteInput{
+			Query: "test",
+		},
+	)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if output.IsPlaylist {
+		t.Error("expected IsPlaylist = false for nil resolver")
+	}
+
+	if len(output.Tracks) != 0 {
+		t.Errorf("expected 0 tracks for nil resolver, got %d", len(output.Tracks))
+	}
+}
+
+func TestAutocompleteService_LoadTracksForAutocomplete_DefaultLimit(t *testing.T) {
+	// Create a playlist with 30 tracks
+	tracks := make([]*ports.TrackInfo, 30)
+	for i := range 30 {
+		tracks[i] = &ports.TrackInfo{
+			Identifier: string(rune('a' + i)),
+			Title:      "Track " + string(rune('A'+i)),
+		}
+	}
+
+	resolver := &mockTrackResolver{
+		loadResult: &ports.LoadResult{
+			Type:       ports.LoadTypePlaylist,
+			PlaylistID: "Large Playlist",
+			Tracks:     tracks,
+		},
+	}
+
+	service := NewAutocompleteService(nil, resolver)
+	output, err := service.LoadTracksForAutocomplete(
+		context.Background(),
+		LoadTracksForAutocompleteInput{
+			Query: "https://example.com/playlist",
+			// Limit not specified, should default to 24
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if output.TrackCount != 30 {
+		t.Errorf("TrackCount = %d, want 30", output.TrackCount)
+	}
+
+	if len(output.Tracks) != 24 {
+		t.Errorf("len(Tracks) = %d, want 24 (default limit)", len(output.Tracks))
+	}
+}

--- a/internal/modules/music_player/application/usecases/track_loader.go
+++ b/internal/modules/music_player/application/usecases/track_loader.go
@@ -21,6 +21,21 @@ type LoadTrackOutput struct {
 	Track *domain.Track
 }
 
+// LoadTracksInput contains the input for the LoadTracks use case.
+type LoadTracksInput struct {
+	Query              string
+	RequesterID        snowflake.ID
+	RequesterName      string
+	RequesterAvatarURL string
+}
+
+// LoadTracksOutput contains the result of the LoadTracks use case.
+type LoadTracksOutput struct {
+	Tracks       []*domain.Track
+	IsPlaylist   bool
+	PlaylistName string
+}
+
 // TrackLoaderService handles track loading operations.
 type TrackLoaderService struct {
 	trackResolver ports.TrackResolver
@@ -69,6 +84,56 @@ func (s *TrackLoaderService) LoadTrack(
 
 	return &LoadTrackOutput{
 		Track: track,
+	}, nil
+}
+
+// LoadTracks loads tracks from the given query.
+// For playlists, returns all tracks. For single tracks/searches, returns one track.
+func (s *TrackLoaderService) LoadTracks(
+	ctx context.Context,
+	input LoadTracksInput,
+) (*LoadTracksOutput, error) {
+	query := domain.NewSearchQuery(input.Query)
+	result, err := s.trackResolver.LoadTracks(ctx, query.LavalinkQuery())
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Type == ports.LoadTypeEmpty || result.Type == ports.LoadTypeError ||
+		len(result.Tracks) == 0 {
+		return nil, ErrNoResults
+	}
+
+	// Determine which tracks to convert
+	// For playlists, convert all tracks; otherwise just the first one
+	tracksToConvert := result.Tracks
+	if result.Type != ports.LoadTypePlaylist {
+		tracksToConvert = result.Tracks[:1]
+	}
+
+	tracks := make([]*domain.Track, 0, len(tracksToConvert))
+	for _, trackInfo := range tracksToConvert {
+		track := domain.NewTrack(
+			domain.TrackID(trackInfo.Identifier),
+			trackInfo.Encoded,
+			trackInfo.Title,
+			trackInfo.Artist,
+			trackInfo.Duration,
+			trackInfo.URI,
+			trackInfo.ArtworkURL,
+			trackInfo.SourceName,
+			trackInfo.IsStream,
+			input.RequesterID,
+			input.RequesterName,
+			input.RequesterAvatarURL,
+		)
+		tracks = append(tracks, track)
+	}
+
+	return &LoadTracksOutput{
+		Tracks:       tracks,
+		IsPlaylist:   result.Type == ports.LoadTypePlaylist,
+		PlaylistName: result.PlaylistID,
 	}, nil
 }
 

--- a/internal/modules/music_player/domain/queue.go
+++ b/internal/modules/music_player/domain/queue.go
@@ -30,6 +30,18 @@ func (q *Queue) Add(track *Track) (wasIdle bool) {
 	return wasIdle
 }
 
+// AddMultiple adds multiple tracks to the end of the queue atomically.
+// Returns true if the player was idle (no current track), to trigger auto-play.
+// This is more efficient than calling Add() multiple times as it only locks once.
+func (q *Queue) AddMultiple(tracks []*Track) (wasIdle bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	wasIdle = q.currentIndex < 0 || q.currentIndex >= len(q.tracks)
+	q.tracks = append(q.tracks, tracks...)
+	return wasIdle
+}
+
 // Current returns the track at currentIndex, or nil if no current track.
 func (q *Queue) Current() *Track {
 	q.mu.RLock()


### PR DESCRIPTION
Add support for adding entire playlists via the `play` command. When a playlist URL is provided, all tracks are added to the queue at once.

Changes:
- Add `Queue.AddMultiple()` for atomic batch track addition
- Add `TrackLoaderService.LoadTracks()` to return all playlist tracks
- Add `QueueService.AddMultiple()` with single event for first track
- Add `AutocompleteService.LoadTracksForAutocomplete()` for playlist detection
- Update `HandlePlay()` to handle playlists via `AddMultiple()`
- Update autocomplete to show playlist options with emoji prefixes:
  - 📋 for entire playlist
  - 🎵 for individual tracks