### PR TITLE
fix(modules/music_player): clear now playing message ref after deletion

### DIFF
--- a/internal/modules/music_player/application/event_handlers.go
+++ b/internal/modules/music_player/application/event_handlers.go
@@ -233,6 +233,7 @@ func (h *NotificationEventHandler) handleCurrentTrackChanged(
 				"error", err,
 			)
 		}
+		state.SetNowPlayingMessage(nil)
 	}
 
 	current := state.Current()


### PR DESCRIPTION
The `NotificationEventHandler` deleted the old "Now Playing" message but never cleared the reference from state. On the next `CurrentTrackChangedEvent`, the handler attempted to delete the already-gone message, producing a 404.