### PR TITLE
fix(modules/music_player): normalize playlist URLs in autocomplete

### DIFF
--- a/internal/modules/music_player/application/usecases/track_loader_test.go
+++ b/internal/modules/music_player/application/usecases/track_loader_test.go
@@ -47,14 +47,14 @@ func TestTrackLoaderService_ResolveQuery(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		input            ResolveQueryInput
-		setupResolver    func(*mockTrackResolver)
-		wantErr          error
-		wantTrackCount   int
-		wantIsPlaylist   bool
-		wantPlaylistName string
-		wantFirstTitle   string
+		name           string
+		input          ResolveQueryInput
+		setupResolver  func(*mockTrackResolver)
+		wantErr        error
+		wantTrackCount int
+		wantType       string
+		wantName       string
+		wantFirstTitle string
 	}{
 		{
 			name: "single track result returns one track",
@@ -65,7 +65,7 @@ func TestTrackLoaderService_ResolveQuery(t *testing.T) {
 				m.loadResult = singleTrackResult
 			},
 			wantTrackCount: 1,
-			wantIsPlaylist: false,
+			wantType:       "track",
 			wantFirstTitle: "Single Track",
 		},
 		{
@@ -77,7 +77,7 @@ func TestTrackLoaderService_ResolveQuery(t *testing.T) {
 				m.loadResult = searchResult
 			},
 			wantTrackCount: 3,
-			wantIsPlaylist: false,
+			wantType:       "search",
 			wantFirstTitle: "Search Result 1",
 		},
 		{
@@ -88,10 +88,10 @@ func TestTrackLoaderService_ResolveQuery(t *testing.T) {
 			setupResolver: func(m *mockTrackResolver) {
 				m.loadResult = playlistResult
 			},
-			wantTrackCount:   3,
-			wantIsPlaylist:   true,
-			wantPlaylistName: "My Awesome Playlist",
-			wantFirstTitle:   "Playlist Track 1",
+			wantTrackCount: 3,
+			wantType:       "playlist",
+			wantName:       "My Awesome Playlist",
+			wantFirstTitle: "Playlist Track 1",
 		},
 		{
 			name: "no results from resolver",
@@ -145,12 +145,16 @@ func TestTrackLoaderService_ResolveQuery(t *testing.T) {
 				t.Errorf("got %d tracks, want %d", len(output.Tracks), tt.wantTrackCount)
 			}
 
-			if output.IsPlaylist != tt.wantIsPlaylist {
-				t.Errorf("IsPlaylist = %v, want %v", output.IsPlaylist, tt.wantIsPlaylist)
+			if output.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", output.Type, tt.wantType)
 			}
 
-			if output.PlaylistName != tt.wantPlaylistName {
-				t.Errorf("PlaylistName = %q, want %q", output.PlaylistName, tt.wantPlaylistName)
+			gotName := ""
+			if output.Name != nil {
+				gotName = *output.Name
+			}
+			if gotName != tt.wantName {
+				t.Errorf("Name = %q, want %q", gotName, tt.wantName)
 			}
 
 			if len(output.Tracks) > 0 && output.Tracks[0].Title != tt.wantFirstTitle {

--- a/internal/modules/music_player/domain/track_list.go
+++ b/internal/modules/music_player/domain/track_list.go
@@ -9,6 +9,19 @@ const (
 	TrackListTypeSearch
 )
 
+func (t TrackListType) String() string {
+	switch t {
+	case TrackListTypeTrack:
+		return "track"
+	case TrackListTypePlaylist:
+		return "playlist"
+	case TrackListTypeSearch:
+		return "search"
+	default:
+		return ""
+	}
+}
+
 // TrackList represents a collection of tracks.
 type TrackList struct {
 	Type       TrackListType

--- a/internal/modules/music_player/presentation/discord/autocomplete.go
+++ b/internal/modules/music_player/presentation/discord/autocomplete.go
@@ -67,24 +67,18 @@ func (h *AutocompleteHandler) HandlePlay(s *discordgo.Session, i *discordgo.Inte
 
 	choices := make([]*discordgo.ApplicationCommandOptionChoice, 0)
 
-	if output.IsPlaylist {
+	if output.Type == "playlist" && output.Name != nil && output.Url != nil {
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
 			Name: truncate(
-				fmt.Sprintf("📋 %s (%d tracks)", output.PlaylistName, len(output.Tracks)),
+				fmt.Sprintf("📋 %s (%d tracks)", *output.Name, len(output.Tracks)),
 				100,
 			),
-			Value: query,
+			Value: *output.Url,
 		})
 	}
 	for i, track := range output.Tracks {
-		var optionName string
-		if output.IsPlaylist {
-			optionName = fmt.Sprintf("🎵 %d. %s - %s", i+1, track.Title, track.Artist)
-		} else {
-			optionName = fmt.Sprintf("🎵 %s - %s", track.Title, track.Artist)
-		}
 		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
-			Name:  truncate(optionName, 100),
+			Name:  truncate(fmt.Sprintf("🎵 %d. %s - %s", i+1, track.Title, track.Artist), 100),
 			Value: track.URI,
 		})
 	}

--- a/internal/modules/music_player/presentation/discord/command_handlers.go
+++ b/internal/modules/music_player/presentation/discord/command_handlers.go
@@ -199,11 +199,11 @@ func (h *CommandHandlers) HandlePlay(
 	}
 
 	var description string
-	if resolveQueryOutput.IsPlaylist {
+	if resolveQueryOutput.Type == "playlist" && resolveQueryOutput.Name != nil {
 		description = fmt.Sprintf(
 			"Added **%d tracks** from playlist **%s** to the queue.",
 			queueAddOutput.Count,
-			resolveQueryOutput.PlaylistName,
+			*resolveQueryOutput.Name,
 		)
 	} else {
 		track := resolveQueryOutput.Tracks[0]
@@ -891,7 +891,7 @@ func respondError(r bot.Responder, message string) error {
 	})
 }
 
-func respondQueueRemoved(r bot.Responder, track usecases.TrackInfo) error {
+func respondQueueRemoved(r bot.Responder, track usecases.TrackData) error {
 	var description string
 	if track.URI != "" {
 		description = fmt.Sprintf("Removed [%s](%s).", track.Title, track.URI)
@@ -914,7 +914,7 @@ func respondQueueRemoved(r bot.Responder, track usecases.TrackInfo) error {
 
 // writeTrackLine writes a single track line to the string builder.
 // Escapes period to prevent Discord markdown list formatting.
-func writeTrackLine(sb *strings.Builder, displayIndex int, track usecases.TrackInfo) {
+func writeTrackLine(sb *strings.Builder, displayIndex int, track usecases.TrackData) {
 	if track.URI != "" {
 		fmt.Fprintf(
 			sb,


### PR DESCRIPTION
Strip unnecessary parameters from playlist URLs by deriving a canonical URL in the infrastructure layer and passing it through to the presentation layer as the autocomplete choice value.

Closes #21 