### PR TITLE
build: fix version injection in container build

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,5 @@
+builds:
+  - id: sgrbot
+    main: ./cmd/sgrbot
+    ldflags:
+      - -X main.version={{ .Env.VERSION }}


### PR DESCRIPTION
## Summary
- Add `.ko.yaml` to configure `ldflags` so `ko build` injects the `VERSION` env var (commit SHA or tag) into `main.version` at build time
- The container workflow already sets `VERSION` but wasn't passing it through to the Go binary