### PR TITLE
feat(modules/music_player): add `queue shuffle` command

### DIFF
--- a/internal/modules/music_player/application/usecases/queue.go
+++ b/internal/modules/music_player/application/usecases/queue.go
@@ -311,6 +311,42 @@ func (q *QueueService) Clear(
 	}, nil
 }
 
+// QueueShuffleInput contains the input for the QueueShuffle use case.
+type QueueShuffleInput struct {
+	GuildID snowflake.ID
+}
+
+// QueueShuffleOutput contains the result of the QueueShuffle use case.
+type QueueShuffleOutput struct {
+	ShuffledCount int
+}
+
+// Shuffle randomizes the order of tracks in the queue.
+// When playback is active, the current track remains at the front.
+func (q *QueueService) Shuffle(
+	ctx context.Context,
+	input QueueShuffleInput,
+) (*QueueShuffleOutput, error) {
+	state, err := q.playerStates.Get(ctx, input.GuildID)
+	if err != nil {
+		return nil, ErrNotConnected
+	}
+
+	if state.IsEmpty() {
+		return nil, ErrQueueEmpty
+	}
+
+	state.Shuffle()
+
+	if err := q.playerStates.Save(ctx, state); err != nil {
+		return nil, err
+	}
+
+	return &QueueShuffleOutput{
+		ShuffledCount: state.Len(),
+	}, nil
+}
+
 // QueueRestartInput contains the input for the QueueRestart use case.
 type QueueRestartInput struct {
 	GuildID snowflake.ID

--- a/internal/modules/music_player/application/usecases/queue_test.go
+++ b/internal/modules/music_player/application/usecases/queue_test.go
@@ -776,6 +776,142 @@ func TestQueueService_Clear(t *testing.T) {
 	}
 }
 
+func TestQueueService_Shuffle(t *testing.T) {
+	guildID := snowflake.ID(1)
+	voiceChannelID := snowflake.ID(4)
+	notificationChannelID := snowflake.ID(3)
+
+	t.Run("not connected", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+		service := NewQueueService(repo, publisher)
+
+		_, err := service.Shuffle(context.Background(), QueueShuffleInput{GuildID: guildID})
+		if err != ErrNotConnected {
+			t.Errorf("expected ErrNotConnected, got %v", err)
+		}
+	})
+
+	t.Run("empty queue", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+		repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+
+		service := NewQueueService(repo, publisher)
+		_, err := service.Shuffle(context.Background(), QueueShuffleInput{GuildID: guildID})
+		if err != ErrQueueEmpty {
+			t.Errorf("expected ErrQueueEmpty, got %v", err)
+		}
+	})
+
+	t.Run("playing with multiple tracks - current at index 0", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+		state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+		for _, id := range []string{"a", "b", "c", "d", "e"} {
+			state.Append(domain.QueueEntry{TrackID: domain.TrackID(id)})
+		}
+		state.SetPlaybackActive(true)
+		state.Seek(2) // playing "c"
+
+		service := NewQueueService(repo, publisher)
+		output, err := service.Shuffle(context.Background(), QueueShuffleInput{GuildID: guildID})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if output.ShuffledCount != 5 {
+			t.Errorf("ShuffledCount = %d, want 5", output.ShuffledCount)
+		}
+
+		// Verify current track is at index 0
+		updatedState, _ := repo.Get(context.Background(), guildID)
+		if updatedState.CurrentIndex() != 0 {
+			t.Errorf("expected currentIndex 0, got %d", updatedState.CurrentIndex())
+		}
+		current := updatedState.Current()
+		if current == nil || current.TrackID != "c" {
+			t.Errorf("expected current track 'c', got %v", current)
+		}
+
+		// All entries preserved
+		seen := make(map[domain.TrackID]bool)
+		for _, e := range updatedState.List() {
+			seen[e.TrackID] = true
+		}
+		for _, id := range []domain.TrackID{"a", "b", "c", "d", "e"} {
+			if !seen[id] {
+				t.Errorf("missing entry %q after shuffle", id)
+			}
+		}
+
+		// No events published
+		if len(publisher.events) != 0 {
+			t.Errorf("expected 0 events, got %d", len(publisher.events))
+		}
+	})
+
+	t.Run("idle with tracks - shuffles all entries", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+		state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+		for _, id := range []string{"a", "b", "c", "d", "e"} {
+			state.Append(domain.QueueEntry{TrackID: domain.TrackID(id)})
+		}
+		// playback not active
+
+		service := NewQueueService(repo, publisher)
+		output, err := service.Shuffle(context.Background(), QueueShuffleInput{GuildID: guildID})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if output.ShuffledCount != 5 {
+			t.Errorf("ShuffledCount = %d, want 5", output.ShuffledCount)
+		}
+
+		// All entries preserved
+		updatedState, _ := repo.Get(context.Background(), guildID)
+		seen := make(map[domain.TrackID]bool)
+		for _, e := range updatedState.List() {
+			seen[e.TrackID] = true
+		}
+		for _, id := range []domain.TrackID{"a", "b", "c", "d", "e"} {
+			if !seen[id] {
+				t.Errorf("missing entry %q after shuffle", id)
+			}
+		}
+
+		// No events published
+		if len(publisher.events) != 0 {
+			t.Errorf("expected 0 events, got %d", len(publisher.events))
+		}
+	})
+
+	t.Run("single track - success (no-op)", func(t *testing.T) {
+		repo := newMockRepository()
+		publisher := &mockEventPublisher{}
+		state := repo.createConnectedState(guildID, voiceChannelID, notificationChannelID)
+		state.Append(domain.QueueEntry{TrackID: domain.TrackID("only")})
+		state.SetPlaybackActive(true)
+
+		service := NewQueueService(repo, publisher)
+		output, err := service.Shuffle(context.Background(), QueueShuffleInput{GuildID: guildID})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if output.ShuffledCount != 1 {
+			t.Errorf("ShuffledCount = %d, want 1", output.ShuffledCount)
+		}
+
+		// No events published
+		if len(publisher.events) != 0 {
+			t.Errorf("expected 0 events, got %d", len(publisher.events))
+		}
+	})
+}
+
 func TestQueueService_Restart(t *testing.T) {
 	guildID := snowflake.ID(1)
 	voiceChannelID := snowflake.ID(4)

--- a/internal/modules/music_player/domain/player_state.go
+++ b/internal/modules/music_player/domain/player_state.go
@@ -265,6 +265,27 @@ func (p *PlayerState) Remove(index int) (*QueueEntry, error) {
 	return entry, nil
 }
 
+// Shuffle randomizes the order of entries in the queue.
+// When playback is active, the currently playing track is moved to index 0
+// so playback continues uninterrupted.
+func (p *PlayerState) Shuffle() {
+	current := p.Current() // nil if idle
+	var savedEntry QueueEntry
+	if current != nil {
+		savedEntry = *current // copy value before shuffle mutates the slice
+	}
+	p.queue.Shuffle()
+	if current != nil {
+		for i, e := range p.queue.entries {
+			if e == savedEntry {
+				p.queue.entries[0], p.queue.entries[i] = p.queue.entries[i], p.queue.entries[0]
+				break
+			}
+		}
+		p.currentIndex = 0
+	}
+}
+
 // Clear removes all entries from the queue and resets playback state.
 func (p *PlayerState) Clear() {
 	p.queue.Clear()

--- a/internal/modules/music_player/domain/player_state_test.go
+++ b/internal/modules/music_player/domain/player_state_test.go
@@ -764,6 +764,91 @@ func TestPlayerState_QueuePrepend(t *testing.T) {
 	})
 }
 
+func TestPlayerState_Shuffle(t *testing.T) {
+	t.Run("active playback - current track moves to index 0", func(t *testing.T) {
+		state := newTestPlayerState()
+		state.Append(testEntry("a"), testEntry("b"), testEntry("c"), testEntry("d"), testEntry("e"))
+		state.SetPlaybackActive(true)
+		state.Seek(2) // playing "c"
+
+		state.Shuffle()
+
+		// Current track should now be at index 0
+		if state.CurrentIndex() != 0 {
+			t.Errorf("expected currentIndex 0, got %d", state.CurrentIndex())
+		}
+		current := state.Current()
+		if current == nil || current.TrackID != "c" {
+			t.Errorf("expected current track 'c', got %v", current)
+		}
+
+		// All entries should be preserved
+		if state.Len() != 5 {
+			t.Fatalf("expected 5 entries, got %d", state.Len())
+		}
+		seen := make(map[TrackID]bool)
+		for _, e := range state.List() {
+			seen[e.TrackID] = true
+		}
+		for _, id := range []TrackID{"a", "b", "c", "d", "e"} {
+			if !seen[id] {
+				t.Errorf("missing entry %q after shuffle", id)
+			}
+		}
+	})
+
+	t.Run("idle - all entries shuffled, currentIndex unchanged", func(t *testing.T) {
+		state := newTestPlayerState()
+		state.Append(testEntry("a"), testEntry("b"), testEntry("c"), testEntry("d"), testEntry("e"))
+		// playback not active
+
+		state.Shuffle()
+
+		if state.CurrentIndex() != 0 {
+			t.Errorf("expected currentIndex 0, got %d", state.CurrentIndex())
+		}
+		if state.Len() != 5 {
+			t.Fatalf("expected 5 entries, got %d", state.Len())
+		}
+		seen := make(map[TrackID]bool)
+		for _, e := range state.List() {
+			seen[e.TrackID] = true
+		}
+		for _, id := range []TrackID{"a", "b", "c", "d", "e"} {
+			if !seen[id] {
+				t.Errorf("missing entry %q after shuffle", id)
+			}
+		}
+	})
+
+	t.Run("empty queue is no-op", func(t *testing.T) {
+		state := newTestPlayerState()
+		state.Shuffle() // should not panic
+		if state.Len() != 0 {
+			t.Errorf("expected empty queue, got %d", state.Len())
+		}
+	})
+
+	t.Run("single entry is no-op", func(t *testing.T) {
+		state := newTestPlayerState()
+		state.Append(testEntry("only"))
+		state.SetPlaybackActive(true)
+
+		state.Shuffle()
+
+		if state.Len() != 1 {
+			t.Fatalf("expected 1 entry, got %d", state.Len())
+		}
+		if state.CurrentIndex() != 0 {
+			t.Errorf("expected currentIndex 0, got %d", state.CurrentIndex())
+		}
+		current := state.Current()
+		if current == nil || current.TrackID != "only" {
+			t.Errorf("expected current track 'only', got %v", current)
+		}
+	})
+}
+
 func TestPlayerState_IsAtLast(t *testing.T) {
 	state := newTestPlayerState()
 

--- a/internal/modules/music_player/domain/queue.go
+++ b/internal/modules/music_player/domain/queue.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"errors"
+	"math/rand/v2"
 )
 
 // QueueID uniquely identifies a queue.
@@ -76,6 +77,13 @@ func (q *Queue) Remove(index int) (*QueueEntry, error) {
 	q.entries = append(q.entries[:index], q.entries[index+1:]...)
 
 	return &entry, nil
+}
+
+// Shuffle randomizes the order of entries in the queue.
+func (q *Queue) Shuffle() {
+	rand.Shuffle(len(q.entries), func(i, j int) {
+		q.entries[i], q.entries[j] = q.entries[j], q.entries[i]
+	})
 }
 
 // Clear removes all entries from the queue.

--- a/internal/modules/music_player/domain/queue_test.go
+++ b/internal/modules/music_player/domain/queue_test.go
@@ -156,6 +156,53 @@ func TestQueue_Prepend(t *testing.T) {
 	}
 }
 
+func TestQueue_Shuffle(t *testing.T) {
+	t.Run("preserves all entries", func(t *testing.T) {
+		q := NewQueue()
+		q.Append(entry("a"), entry("b"), entry("c"), entry("d"), entry("e"))
+
+		q.Shuffle()
+
+		if q.Len() != 5 {
+			t.Fatalf("expected length 5, got %d", q.Len())
+		}
+
+		// Verify all original entries are still present
+		seen := make(map[TrackID]bool)
+		for _, e := range q.List() {
+			seen[e.TrackID] = true
+		}
+		for _, id := range []TrackID{"a", "b", "c", "d", "e"} {
+			if !seen[id] {
+				t.Errorf("missing entry %q after shuffle", id)
+			}
+		}
+	})
+
+	t.Run("empty queue is no-op", func(t *testing.T) {
+		q := NewQueue()
+		q.Shuffle() // should not panic
+		if q.Len() != 0 {
+			t.Errorf("expected empty queue, got length %d", q.Len())
+		}
+	})
+
+	t.Run("single entry queue is no-op", func(t *testing.T) {
+		q := NewQueue()
+		q.Append(entry("only"))
+
+		q.Shuffle()
+
+		if q.Len() != 1 {
+			t.Fatalf("expected length 1, got %d", q.Len())
+		}
+		got, _ := q.Get(0)
+		if got.TrackID != "only" {
+			t.Errorf("expected track 'only', got %q", got.TrackID)
+		}
+	})
+}
+
 func TestQueue_Append(t *testing.T) {
 	q := NewQueue()
 	trackID1 := TrackID("track-1")

--- a/internal/modules/music_player/presentation/discord/command_handlers.go
+++ b/internal/modules/music_player/presentation/discord/command_handlers.go
@@ -419,6 +419,8 @@ func (h *CommandHandlers) HandleQueue(
 		return h.handleQueueClear(s, i, r)
 	case "restart":
 		return h.handleQueueRestart(s, i, r)
+	case "shuffle":
+		return h.handleQueueShuffle(s, i, r)
 	case "seek":
 		return h.handleQueueSeek(s, i, r, subCmd.Options)
 	default:
@@ -711,6 +713,49 @@ func (h *CommandHandlers) handleQueueRestart(
 			Embeds: []*discordgo.MessageEmbed{
 				{
 					Description: "Restarted the queue from the beginning.",
+					Color:       colorSuccess,
+				},
+			},
+		},
+	})
+}
+
+func (h *CommandHandlers) handleQueueShuffle(
+	_ *discordgo.Session,
+	i *discordgo.InteractionCreate,
+	r bot.Responder,
+) error {
+	ctx := context.Background()
+
+	guildID, err := snowflake.Parse(i.GuildID)
+	if err != nil {
+		return respondError(r, "Invalid guild")
+	}
+
+	notificationChannelID, err := snowflake.Parse(i.ChannelID)
+	if err != nil {
+		return respondError(r, "Invalid notification channel")
+	}
+
+	// Update notification channel (best-effort)
+	_ = h.notificationChannel.Set(ctx, usecases.SetNotificationChannelInput{
+		GuildID:   guildID,
+		ChannelID: notificationChannelID,
+	})
+
+	_, err = h.queue.Shuffle(ctx, usecases.QueueShuffleInput{
+		GuildID: guildID,
+	})
+	if err != nil {
+		return respondError(r, err.Error())
+	}
+
+	return r.Respond(&discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Description: "Shuffled the queue.",
 					Color:       colorSuccess,
 				},
 			},

--- a/internal/modules/music_player/presentation/discord/commands.go
+++ b/internal/modules/music_player/presentation/discord/commands.go
@@ -99,6 +99,11 @@ func Commands() []*discordgo.ApplicationCommand {
 				},
 				{
 					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Name:        "shuffle",
+					Description: "Shuffle the queue",
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
 					Name:        "seek",
 					Description: "Jump to a specific position in the queue",
 					Options: []*discordgo.ApplicationCommandOption{


### PR DESCRIPTION
## Summary

- Add `Queue.Shuffle()` and `PlayerState.Shuffle()` domain methods using `math/rand/v2`
- Add `QueueService.Shuffle()` usecase with not-connected/empty-queue error handling
- Add `/queue shuffle` subcommand and handler in the presentation layer
- When playback is active, the current track is moved to the front after shuffling so playback continues uninterrupted