### PR TITLE
fix(modules/music_player): resolve stale seed selection in auto-play recommendations

### DIFF
--- a/internal/modules/music_player/application/event_handlers.go
+++ b/internal/modules/music_player/application/event_handlers.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"reflect"
 	"time"
 
@@ -14,12 +15,13 @@ import (
 // PlaybackEventHandler handles events related to playback control.
 // It subscribes to CurrentTrackChanged and TrackEnded events to manage playback flow.
 type PlaybackEventHandler struct {
-	playerStates domain.PlayerStateRepository
-	player       ports.AudioPlayer
-	publisher    ports.EventPublisher
-	subscriber   ports.EventSubscriber
-	recommender  ports.TrackRecommender
-	botUserID    snowflake.ID
+	playerStates  domain.PlayerStateRepository
+	player        ports.AudioPlayer
+	publisher     ports.EventPublisher
+	subscriber    ports.EventSubscriber
+	recommender   ports.TrackRecommender
+	trackProvider ports.TrackProvider
+	botUserID     snowflake.ID
 }
 
 // NewPlaybackEventHandler creates a new PlaybackEventHandler.
@@ -29,15 +31,17 @@ func NewPlaybackEventHandler(
 	publisher ports.EventPublisher,
 	subscriber ports.EventSubscriber,
 	recommender ports.TrackRecommender,
+	trackProvider ports.TrackProvider,
 	botUserID snowflake.ID,
 ) *PlaybackEventHandler {
 	return &PlaybackEventHandler{
-		playerStates: playerStates,
-		player:       player,
-		subscriber:   subscriber,
-		publisher:    publisher,
-		recommender:  recommender,
-		botUserID:    botUserID,
+		playerStates:  playerStates,
+		player:        player,
+		subscriber:    subscriber,
+		publisher:     publisher,
+		recommender:   recommender,
+		trackProvider: trackProvider,
+		botUserID:     botUserID,
 	}
 }
 
@@ -193,15 +197,88 @@ func (h *PlaybackEventHandler) tryAutoPlay(
 	ctx context.Context,
 	state *domain.PlayerState,
 ) bool {
-	// Collect seed and exclude track IDs from queue
+	// Collect seed and exclude track IDs using a weighted mix:
+	// up to 2 randomly sampled manually added YouTube tracks + the most recent
+	// auto-play YouTube track.
+	// This keeps recommendations anchored to the user's selections while allowing
+	// natural progression via the latest auto-play track.
 	allEntries := state.List()
-	seeds := make([]domain.TrackID, 0)
-	exclude := make([]domain.TrackID, 0)
+	var manualIDs []domain.TrackID
+	var autoPlayIDs []domain.TrackID
 	for _, entry := range allEntries {
 		if entry.IsAutoPlay {
-			exclude = append(exclude, entry.TrackID)
+			autoPlayIDs = append(autoPlayIDs, entry.TrackID)
 		} else {
-			seeds = append(seeds, entry.TrackID)
+			manualIDs = append(manualIDs, entry.TrackID)
+		}
+	}
+
+	seeds := make([]domain.TrackID, 0, 3)
+	seedSet := make(map[domain.TrackID]struct{}, 3)
+
+	// Sample up to 2 manual YouTube seeds
+	rand.Shuffle(len(manualIDs), func(i, j int) {
+		manualIDs[i], manualIDs[j] = manualIDs[j], manualIDs[i]
+	})
+	for _, id := range manualIDs {
+		if len(seeds) >= 2 {
+			break
+		}
+		track, err := h.trackProvider.LoadTrack(ctx, id)
+		if err != nil {
+			slog.Debug(
+				"failed to load manual seed track",
+				"track", id,
+				"error", err,
+			)
+			continue
+		}
+		if track.Source != domain.TrackSourceYouTube {
+			continue
+		}
+		if _, exists := seedSet[id]; exists {
+			continue
+		}
+		seedSet[id] = struct{}{}
+		seeds = append(seeds, id)
+	}
+
+	// Add the most recent auto-play YouTube track as a seed
+	for i := len(autoPlayIDs) - 1; i >= 0; i-- {
+		id := autoPlayIDs[i]
+		if _, exists := seedSet[id]; exists {
+			continue
+		}
+		track, err := h.trackProvider.LoadTrack(ctx, id)
+		if err != nil {
+			slog.Debug(
+				"failed to load auto-play seed track",
+				"track", id,
+				"error", err,
+			)
+			continue
+		}
+		if track.Source != domain.TrackSourceYouTube {
+			continue
+		}
+		seedSet[id] = struct{}{}
+		seeds = append(seeds, id)
+		break
+	}
+
+	if len(seeds) == 0 {
+		slog.Debug(
+			"auto-play has no YouTube seeds",
+			"guild", state.GetGuildID(),
+		)
+		return false
+	}
+
+	// Exclude all tracks not selected as seeds
+	var exclude []domain.TrackID
+	for _, entry := range allEntries {
+		if _, isSeed := seedSet[entry.TrackID]; !isSeed {
+			exclude = append(exclude, entry.TrackID)
 		}
 	}
 

--- a/internal/modules/music_player/infrastructure/track_recommender.go
+++ b/internal/modules/music_player/infrastructure/track_recommender.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand/v2"
 	"sort"
 
 	"github.com/sglre6355/sgrbot/internal/modules/music_player/application/ports"
@@ -13,9 +12,6 @@ import (
 
 // Ensure TrackRecommenderAdapter implements required ports.
 var _ ports.TrackRecommender = (*TrackRecommenderAdapter)(nil)
-
-// maxMixSeeds is the maximum number of YouTube seeds to sample for mix playlists.
-const maxMixSeeds = 3
 
 // TrackRecommenderAdapter recommends tracks using YouTube Mix playlists.
 type TrackRecommenderAdapter struct {
@@ -30,7 +26,8 @@ func NewTrackRecommenderAdapter(trackProvider ports.TrackProvider) *TrackRecomme
 }
 
 // Recommend returns up to limit recommended tracks based on the given seed track IDs.
-// Tracks with IDs in the exclude list are also filtered out.
+// Tracks with IDs in the exclude list are also filtered out. Seeds should be
+// YouTube track IDs so they can be used for YouTube Mix playlists.
 // It uses YouTube Mix playlists (RD{trackID}) to find related tracks, then ranks
 // them by how many mixes they appear in (overlap score).
 func (a *TrackRecommenderAdapter) Recommend(
@@ -43,12 +40,6 @@ func (a *TrackRecommenderAdapter) Recommend(
 		return []domain.Track{}, nil
 	}
 
-	// Load track metadata for all seeds to find YouTube-sourced tracks
-	tracks, err := a.trackProvider.LoadTracks(ctx, seeds...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load seed tracks: %w", err)
-	}
-
 	// Build exclude set from all seed IDs and explicit excludes
 	excludeSet := make(map[domain.TrackID]struct{}, len(seeds)+len(exclude))
 	for _, id := range seeds {
@@ -58,46 +49,25 @@ func (a *TrackRecommenderAdapter) Recommend(
 		excludeSet[id] = struct{}{}
 	}
 
-	// Filter to YouTube-sourced tracks
-	var ytTracks []domain.Track
-	for _, t := range tracks {
-		if t.Source == domain.TrackSourceYouTube {
-			ytTracks = append(ytTracks, t)
-		}
-	}
-
-	if len(ytTracks) == 0 {
-		return []domain.Track{}, nil
-	}
-
-	// Randomly sample up to maxMixSeeds YouTube seeds
-	sampled := ytTracks
-	if len(sampled) > maxMixSeeds {
-		rand.Shuffle(len(sampled), func(i, j int) {
-			sampled[i], sampled[j] = sampled[j], sampled[i]
-		})
-		sampled = sampled[:maxMixSeeds]
-	}
-
-	// For each sampled seed, load the YouTube Mix playlist
+	// For each seed, load the YouTube Mix playlist
 	type scoredTrack struct {
 		track domain.Track
 		score int
 	}
 	trackScores := make(map[domain.TrackID]*scoredTrack)
 
-	for _, seed := range sampled {
+	for _, seed := range seeds {
 		mixURL := fmt.Sprintf(
 			"https://www.youtube.com/watch?v=%s&list=RD%s",
-			seed.ID.String(),
-			seed.ID.String(),
+			seed.String(),
+			seed.String(),
 		)
 
 		trackList, err := a.trackProvider.ResolveQuery(ctx, mixURL)
 		if err != nil {
 			slog.Debug(
 				"failed to load YouTube Mix",
-				"seed", seed.ID,
+				"seed", seed,
 				"error", err,
 			)
 			continue

--- a/internal/modules/music_player/module.go
+++ b/internal/modules/music_player/module.go
@@ -182,6 +182,7 @@ func (m *MusicPlayerModule) initWithLavalink(deps bot.ModuleDependencies) error 
 		m.eventBus,
 		m.eventBus,
 		trackRecommender,
+		lavalinkAdapter,
 		botID,
 	)
 	m.notificationHandler = application.NewNotificationEventHandler(


### PR DESCRIPTION
Previously, only manually added tracks were used as seeds, so a queue with a single manual track would always load the same YouTube Mix playlist. Compose seeds as 2 randomly sampled manual tracks + the most recent auto-play track, allowing recommendations to evolve while staying anchored to the user's selections.