### PR TITLE
fix(modules/music_player): stop resetting voice event buffer after forwarding to Lavalink

### DIFF
--- a/internal/modules/music_player/infrastructure/lavalink_client.go
+++ b/internal/modules/music_player/infrastructure/lavalink_client.go
@@ -97,25 +97,16 @@ func (b *voiceEventBuffer) setVoiceServer(token, endpoint string) bool {
 	return b.hasVoiceState && b.hasVoiceServer
 }
 
-// getData returns the buffered data and resets the buffer.
+// getData returns the buffered data.
+// The buffer retains values so that a subsequent lone VoiceServerUpdate
+// (e.g. Discord voice server rotation) can be forwarded immediately
+// using the existing session info. Cleanup is handled by clearVoiceBuffer
+// on disconnect.
 func (b *voiceEventBuffer) getData() (channelID *snowflake.ID, sessionID, token, endpoint string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	channelID = b.channelID
-	sessionID = b.sessionID
-	token = b.token
-	endpoint = b.endpoint
-
-	// Reset buffer
-	b.hasVoiceState = false
-	b.hasVoiceServer = false
-	b.channelID = nil
-	b.sessionID = ""
-	b.token = ""
-	b.endpoint = ""
-
-	return
+	return b.channelID, b.sessionID, b.token, b.endpoint
 }
 
 // LavalinkAdapter wraps DisGoLink to implement the port interfaces.


### PR DESCRIPTION
## Summary
- After prolonged playback, Discord rotates voice servers by sending a new `VoiceServerUpdate` event (without a `VoiceStateUpdate`). The `voiceEventBuffer.getData()` method was resetting its state after the initial forwarding, so the lone `VoiceServerUpdate` was never forwarded to Lavalink. This caused Lavalink's voice connection to go stale, resulting in silent playback while the bot otherwise continued to function normally.
- Fix: retain buffered values in `getData()` so that a subsequent lone `VoiceServerUpdate` passes the readiness check and is forwarded immediately.