### PR TITLE
ci: fix Claude code review action producing no PR output

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          track_progress: true
           allowed_bots: 'dependabot[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Grant write permissions for `pull-requests` and `issues` (were `read`)
- Enable `track_progress: true` to force tag mode so the review comment is actually posted

Ref: https://github.com/anthropics/claude-code-action/issues/944#issuecomment-3980807613