### PR TITLE
fix(modules/music_player): limit `/play` search to single best match

### DIFF
--- a/internal/modules/music_player/application/usecases/resolve_query.go
+++ b/internal/modules/music_player/application/usecases/resolve_query.go
@@ -11,6 +11,7 @@ import (
 // ResolveQueryInput holds the input for the ResolveQuery use case.
 type ResolveQueryInput struct {
 	Query string
+	Limit int // Caps the number of tracks returned for search results. Zero means no limit.
 }
 
 // ResolveQueryOutput holds the output for the ResolveQuery use case.
@@ -40,6 +41,10 @@ func (uc *ResolveQueryUsecase) Execute(
 
 	if len(trackList.Tracks) == 0 {
 		return nil, ErrNoResults
+	}
+
+	if input.Limit > 0 && len(trackList.Tracks) > input.Limit {
+		trackList.Tracks = trackList.Tracks[:input.Limit]
 	}
 
 	return &ResolveQueryOutput{

--- a/internal/modules/music_player/application/usecases/resolve_query_test.go
+++ b/internal/modules/music_player/application/usecases/resolve_query_test.go
@@ -14,6 +14,7 @@ func TestResolveQueryUsecase_Execute(t *testing.T) {
 	}
 	type args struct {
 		query string
+		limit int
 	}
 	type want struct {
 		trackCount int
@@ -47,6 +48,39 @@ func TestResolveQueryUsecase_Execute(t *testing.T) {
 			want: want{err: ErrNoResults},
 		},
 		{
+			name: "limit truncates search results",
+			deps: deps{resolver: &stubTrackResolver{
+				result: domain.NewTrackList(
+					domain.TrackListTypeSearch,
+					[]domain.Track{newTestTrack("t1"), newTestTrack("t2"), newTestTrack("t3")},
+				),
+			}},
+			args: args{query: "test", limit: 1},
+			want: want{trackCount: 1, firstID: "t1"},
+		},
+		{
+			name: "zero limit returns all results",
+			deps: deps{resolver: &stubTrackResolver{
+				result: domain.NewTrackList(
+					domain.TrackListTypeSearch,
+					[]domain.Track{newTestTrack("t1"), newTestTrack("t2"), newTestTrack("t3")},
+				),
+			}},
+			args: args{query: "test", limit: 0},
+			want: want{trackCount: 3, firstID: "t1"},
+		},
+		{
+			name: "limit does not truncate when results are within limit",
+			deps: deps{resolver: &stubTrackResolver{
+				result: domain.NewTrackList(
+					domain.TrackListTypeSearch,
+					[]domain.Track{newTestTrack("t1")},
+				),
+			}},
+			args: args{query: "test", limit: 5},
+			want: want{trackCount: 1, firstID: "t1"},
+		},
+		{
 			name: "resolver error returns ErrInternal",
 			deps: deps{resolver: &stubTrackResolver{
 				err: errors.New("connection failed"),
@@ -60,7 +94,10 @@ func TestResolveQueryUsecase_Execute(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			uc := NewResolveQueryUsecase(tt.deps.resolver)
 
-			out, err := uc.Execute(context.Background(), ResolveQueryInput{Query: tt.args.query})
+			out, err := uc.Execute(
+				context.Background(),
+				ResolveQueryInput{Query: tt.args.query, Limit: tt.args.limit},
+			)
 
 			if tt.want.err != nil {
 				if !errors.Is(err, tt.want.err) {

--- a/internal/modules/music_player/presentation/autocomplete_handlers.go
+++ b/internal/modules/music_player/presentation/autocomplete_handlers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sglre6355/sgrbot/internal/modules/music_player/platforms/discord"
 )
 
-const queueAutocompletePageSize = 25
+const autocompleteLimit = 25
 
 // AutocompleteHandler handles autocomplete requests.
 type AutocompleteHandler struct {
@@ -83,6 +83,7 @@ func (h *AutocompleteHandler) handlePlay(s *discordgo.Session, i *discordgo.Inte
 
 	output, err := h.resolveQuery.Execute(ctx, usecases.ResolveQueryInput{
 		Query: query,
+		Limit: autocompleteLimit,
 	})
 	if err != nil || len(output.Tracks) == 0 {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -149,7 +150,7 @@ func (h *AutocompleteHandler) handleQueuePositionAutocomplete(
 		usecases.ListQueueInput[discord.PartialVoiceConnectionInfo]{
 			ConnectionInfo: connInfo,
 			Page:           1,
-			PageSize:       queueAutocompletePageSize,
+			PageSize:       autocompleteLimit,
 		},
 	)
 	if err != nil {

--- a/internal/modules/music_player/presentation/command_handlers.go
+++ b/internal/modules/music_player/presentation/command_handlers.go
@@ -239,6 +239,7 @@ func (h *CommandHandlers) HandlePlay(
 	// Resolve query
 	resolveOutput, err := h.resolveQuery.Execute(ctx, usecases.ResolveQueryInput{
 		Query: query,
+		Limit: 1,
 	})
 	if err != nil {
 		return respondError(r, err)


### PR DESCRIPTION
Previously, `/play` with a search term added all search results to the queue. Add a `Limit` field to `ResolveQueryInput` so the use case controls truncation, and set `Limit: 1` in the play handler.