### PR TITLE
refactor(modules/music_player): move current-track removal logic into usecase

### DIFF
--- a/internal/modules/music_player/application/usecases/errors.go
+++ b/internal/modules/music_player/application/usecases/errors.go
@@ -8,7 +8,6 @@ var (
 	ErrUserNotInVoice  = errors.New("you must be in a voice channel")
 	ErrNoResults       = errors.New("no results found")
 	ErrQueueEmpty      = errors.New("the queue is empty")
-	ErrIsCurrentTrack  = errors.New("cannot remove the currently playing track")
 	ErrInvalidIndex    = errors.New("invalid position")
 	ErrNotPlaying      = errors.New("nothing is currently playing")
 	ErrAlreadyPaused   = errors.New("playback is already paused")

--- a/internal/modules/music_player/application/usecases/remove_from_queue.go
+++ b/internal/modules/music_player/application/usecases/remove_from_queue.go
@@ -66,7 +66,10 @@ func (uc *RemoveFromQueueUsecase[C]) Execute(
 	var events []domain.Event
 	shouldRemoveCurrent := state.IsPlaybackActive() && input.Index == state.CurrentIndex()
 
-	// If removing the currently playing track, skip first.
+	// If removing the currently playing track, skip first so that
+	// `TrackStartedEvent` is emitted by `Skip` rather than by `Remove`.
+	// This means events are ordered [TrackStartedEvent, TrackRemovedEvent]
+	// instead of [TrackRemovedEvent, TrackStartedEvent].
 	if shouldRemoveCurrent {
 		_, skipEvents, err := uc.player.Skip(&state)
 		if err != nil {

--- a/internal/modules/music_player/application/usecases/remove_from_queue.go
+++ b/internal/modules/music_player/application/usecases/remove_from_queue.go
@@ -90,6 +90,10 @@ func (uc *RemoveFromQueueUsecase[C]) Execute(
 
 	if shouldRemoveCurrent {
 		// Update audio only when playback advanced or stopped.
+		// NOTE: The earlier Skip call may emit QueueExhaustedEvent, which can
+		// trigger auto-play via HandleQueueExhausted (same as SkipTrackUsecase).
+		// When the queue has remaining tracks, audio.Play starts the next track;
+		// otherwise audio.Stop is called, but auto-play may restart playback.
 		if current := state.Current(); current != nil {
 			if err := uc.audio.Play(ctx, state.ID(), *current); err != nil {
 				return nil, errors.Join(ErrInternal, err)

--- a/internal/modules/music_player/application/usecases/remove_from_queue.go
+++ b/internal/modules/music_player/application/usecases/remove_from_queue.go
@@ -24,6 +24,7 @@ type RemoveFromQueueOutput struct {
 type RemoveFromQueueUsecase[C comparable] struct {
 	player             *domain.PlayerService
 	playerStates       domain.PlayerStateRepository
+	audio              ports.AudioGateway
 	events             ports.EventPublisher
 	playerStateLocator ports.PlayerStateLocator[C]
 }
@@ -32,19 +33,21 @@ type RemoveFromQueueUsecase[C comparable] struct {
 func NewRemoveFromQueueUsecase[C comparable](
 	player *domain.PlayerService,
 	playerStates domain.PlayerStateRepository,
+	audio ports.AudioGateway,
 	events ports.EventPublisher,
 	playerStateLocator ports.PlayerStateLocator[C],
 ) *RemoveFromQueueUsecase[C] {
 	return &RemoveFromQueueUsecase[C]{
 		player:             player,
 		playerStates:       playerStates,
+		audio:              audio,
 		events:             events,
 		playerStateLocator: playerStateLocator,
 	}
 }
 
 // Execute removes the track at the given index.
-// Returns ErrIsCurrentTrack if the index points to the currently playing track.
+// If the index points to the currently playing track, it skips playback first.
 func (uc *RemoveFromQueueUsecase[C]) Execute(
 	ctx context.Context,
 	input RemoveFromQueueInput[C],
@@ -60,20 +63,42 @@ func (uc *RemoveFromQueueUsecase[C]) Execute(
 		return nil, errors.Join(ErrInternal, err)
 	}
 
-	if state.IsPlaybackActive() && input.Index == state.CurrentIndex() {
-		return nil, ErrIsCurrentTrack
+	var events []domain.Event
+	shouldRemoveCurrent := state.IsPlaybackActive() && input.Index == state.CurrentIndex()
+
+	// If removing the currently playing track, skip first.
+	if shouldRemoveCurrent {
+		_, skipEvents, err := uc.player.Skip(&state)
+		if err != nil {
+			return nil, errors.Join(ErrInternal, err)
+		}
+		events = append(events, skipEvents...)
 	}
 
-	entry, events, err := uc.player.Remove(&state, input.Index)
+	entry, removeEvents, err := uc.player.Remove(&state, input.Index)
 	if err != nil {
 		if errors.Is(err, domain.ErrInvalidIndex) {
 			return nil, ErrInvalidIndex
 		}
 		return nil, errors.Join(ErrInternal, err)
 	}
+	events = append(events, removeEvents...)
 
 	if err := uc.playerStates.Save(ctx, state); err != nil {
 		return nil, errors.Join(ErrInternal, err)
+	}
+
+	if shouldRemoveCurrent {
+		// Update audio only when playback advanced or stopped.
+		if current := state.Current(); current != nil {
+			if err := uc.audio.Play(ctx, state.ID(), *current); err != nil {
+				return nil, errors.Join(ErrInternal, err)
+			}
+		} else {
+			if err := uc.audio.Stop(ctx, state.ID()); err != nil {
+				return nil, errors.Join(ErrInternal, err)
+			}
+		}
 	}
 
 	uc.events.Publish(ctx, events...)

--- a/internal/modules/music_player/application/usecases/remove_from_queue_test.go
+++ b/internal/modules/music_player/application/usecases/remove_from_queue_test.go
@@ -17,8 +17,10 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 		index int
 	}
 	type want struct {
-		removedID string
-		err       error
+		removedID     string
+		audioPlayedID string
+		audioStopped  bool
+		err           error
 	}
 
 	tests := []struct {
@@ -37,7 +39,7 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 			want: want{err: ErrNotConnected},
 		},
 		{
-			name: "remove current track returns ErrIsCurrentTrack",
+			name: "remove current track skips and removes",
 			deps: deps{
 				state: func() domain.PlayerState { return newActiveState("1", "2") },
 				locator: func(id domain.PlayerStateID) *stubPlayerStateLocator {
@@ -45,7 +47,7 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 				},
 			},
 			args: args{index: 0},
-			want: want{err: ErrIsCurrentTrack},
+			want: want{removedID: "1", audioPlayedID: "2"},
 		},
 		{
 			name: "remove non-current track succeeds",
@@ -57,6 +59,17 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 			},
 			args: args{index: 1},
 			want: want{removedID: "2"},
+		},
+		{
+			name: "remove only current track stops audio",
+			deps: deps{
+				state: func() domain.PlayerState { return newActiveState("1") },
+				locator: func(id domain.PlayerStateID) *stubPlayerStateLocator {
+					return newStubLocator(map[string]domain.PlayerStateID{"guild1": id})
+				},
+			},
+			args: args{index: 0},
+			want: want{removedID: "1", audioStopped: true},
 		},
 		{
 			name: "invalid index returns ErrInvalidIndex",
@@ -74,11 +87,13 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			state := tt.deps.state()
+			audio := &stubAudioGateway{}
 			events := &stubEventPublisher{}
 
 			uc := NewRemoveFromQueueUsecase[string](
 				newPlayerService(),
 				newStubPlayerStateRepo(state),
+				audio,
 				events,
 				tt.deps.locator(state.ID()),
 			)
@@ -100,6 +115,27 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 			}
 			if out.RemovedTrack.ID != tt.want.removedID {
 				t.Errorf("RemovedTrack.ID: got %q, want %q", out.RemovedTrack.ID, tt.want.removedID)
+			}
+			if tt.want.audioPlayedID == "" {
+				if len(audio.playedEntries) != 0 {
+					t.Fatalf("audio played: got %d entries, want 0", len(audio.playedEntries))
+				}
+			} else {
+				if len(audio.playedEntries) != 1 {
+					t.Fatalf("audio played: got %d entries, want 1", len(audio.playedEntries))
+				}
+				if got := string(
+					audio.playedEntries[0].Track().ID(),
+				); got != tt.want.audioPlayedID {
+					t.Errorf("audio played track: got %q, want %q", got, tt.want.audioPlayedID)
+				}
+			}
+			if tt.want.audioStopped {
+				if len(audio.stopped) != 1 {
+					t.Fatalf("audio stopped: got %d calls, want 1", len(audio.stopped))
+				}
+			} else if len(audio.stopped) != 0 {
+				t.Fatalf("audio stopped: got %d calls, want 0", len(audio.stopped))
 			}
 			if len(events.published) == 0 {
 				t.Error("expected events to be published")

--- a/internal/modules/music_player/application/usecases/remove_from_queue_test.go
+++ b/internal/modules/music_player/application/usecases/remove_from_queue_test.go
@@ -72,6 +72,23 @@ func TestRemoveFromQueueUsecase_Execute(t *testing.T) {
 			want: want{removedID: "1", audioStopped: true},
 		},
 		{
+			name: "remove current track while paused skips and plays next",
+			deps: deps{
+				state: func() domain.PlayerState {
+					s := newActiveState("1", "2")
+					if err := s.Pause(); err != nil {
+						panic("setup Pause: " + err.Error())
+					}
+					return s
+				},
+				locator: func(id domain.PlayerStateID) *stubPlayerStateLocator {
+					return newStubLocator(map[string]domain.PlayerStateID{"guild1": id})
+				},
+			},
+			args: args{index: 0},
+			want: want{removedID: "1", audioPlayedID: "2"},
+		},
+		{
 			name: "invalid index returns ErrInvalidIndex",
 			deps: deps{
 				state: func() domain.PlayerState { return newActiveState("1") },

--- a/internal/modules/music_player/module.go
+++ b/internal/modules/music_player/module.go
@@ -209,6 +209,7 @@ func (m *MusicPlayerModule) initWithLavalink(deps bot.ModuleDependencies) error 
 	removeFromQueue := usecases.NewRemoveFromQueueUsecase(
 		playerService,
 		playerStateRepository,
+		audioGateway,
 		m.eventBus,
 		voiceConnectionGateway,
 	)

--- a/internal/modules/music_player/presentation/command_handlers.go
+++ b/internal/modules/music_player/presentation/command_handlers.go
@@ -593,28 +593,6 @@ func (h *CommandHandlers) handleQueueRemove(
 		},
 	)
 	if err != nil {
-		if errors.Is(err, usecases.ErrIsCurrentTrack) {
-			// Skip first, then remove
-			if _, skipErr := h.skipTrack.Execute(
-				ctx,
-				usecases.SkipTrackInput[discord.PartialVoiceConnectionInfo]{
-					ConnectionInfo: connectionInfo,
-				},
-			); skipErr != nil {
-				return respondError(r, skipErr)
-			}
-			removeOutput, removeErr := h.removeFromQueue.Execute(
-				ctx,
-				usecases.RemoveFromQueueInput[discord.PartialVoiceConnectionInfo]{
-					ConnectionInfo: connectionInfo,
-					Index:          index,
-				},
-			)
-			if removeErr != nil {
-				return respondError(r, removeErr)
-			}
-			return respondQueueRemoved(r, removeOutput.RemovedTrack)
-		}
 		return respondError(r, err)
 	}
 


### PR DESCRIPTION
## Summary

This PR moves the "skip current track, then remove it from the queue" flow out of the Discord command handler and into `RemoveFromQueueUsecase`, so the behavior lives in the application layer where it belongs.

With this change, removing the currently playing track becomes a normal usecase operation instead of a presentation-layer special case. The old `ErrIsCurrentTrack` path is removed.

## Changes

- Add `AudioGateway` to `RemoveFromQueueUsecase` so it can coordinate playback when the current track is removed
- Handle current-track removal inside the usecase by:
    - skipping playback first
    - removing the target track
    - updating audio only when playback actually changes
- Keep non-current queue removal as a pure queue edit without restarting playback
- Simplify `handleQueueRemove` by deleting the skip-then-remove fallback logic
- Remove `ErrIsCurrentTrack`
- Update tests to cover:
    - removing the current track and starting the next one
    - removing the only current track and stopping audio
    - removing a non-current track without touching audio

## Why

This keeps queue-removal orchestration in the application layer, reduces presentation-layer branching, and preserves the expected playback behavior for both current and non-current removals.