### PR TITLE
fix(modules/music_player): return user-friendly command errors

### DIFF
--- a/internal/modules/music_player/presentation/command_handlers.go
+++ b/internal/modules/music_player/presentation/command_handlers.go
@@ -862,14 +862,45 @@ func (h *CommandHandlers) HandleLoop(
 
 // Response helpers.
 
+// userFacingMessages maps known usecase errors to user-friendly messages.
+var userFacingMessages = map[error]string{
+	usecases.ErrNotConnected:   "Not connected to a voice channel.",
+	usecases.ErrUserNotInVoice: "You must be in a voice channel, or use /join to specify one.",
+	usecases.ErrNoResults:      "No results found for your query. Try a different search term.",
+	usecases.ErrQueueEmpty:     "The queue is empty.",
+	usecases.ErrInvalidIndex:   "The provided position doesn't exist in the queue.",
+	usecases.ErrNotPlaying:     "Nothing is playing right now.",
+	usecases.ErrAlreadyPaused:  "Playback is already paused.",
+	usecases.ErrNotPaused:      "Playback isn't paused.",
+	errInvalidCommand:          "Invalid command.",
+	errUnknownCommand:          "Unknown command.",
+}
+
+// userFacingMessage returns a user-friendly message for the given error and
+// reports whether the error matched a known user-facing case.
+func userFacingMessage(err error) (string, bool) {
+	for known, message := range userFacingMessages {
+		if errors.Is(err, known) {
+			return message, true
+		}
+	}
+
+	return "Something went wrong. Please try again later.", false
+}
+
 func respondError(r bot.Responder, err error) error {
+	message, known := userFacingMessage(err)
+	if !known {
+		slog.Warn("unknown music player command error", "error", err)
+	}
+
 	return r.Respond(&discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Embeds: []*discordgo.MessageEmbed{
 				{
 					Title:       "Error",
-					Description: err.Error(),
+					Description: message,
 					Color:       colorError,
 				},
 			},


### PR DESCRIPTION
## Summary

Return user-friendly music player command errors and warn on unexpected failures.

## Changes

- map known music player use case errors to clear Discord-facing messages
- return a generic fallback message for unknown errors instead of exposing raw internal error text
- log unknown command errors with `slog.Warn` for diagnosis

## Why

Music player commands were returning `err.Error()` directly in the error embed. That exposed internal error strings to users and made failures inconsistent. This change keeps expected errors actionable for users while preserving visibility into unexpected failures through logs.