### PR TITLE
fix(modules/music_player): resolve Lavalink tracks by URL instead of ID

### DIFF
--- a/internal/modules/music_player/infrastructure/discord/lavalink/audio_gateway.go
+++ b/internal/modules/music_player/infrastructure/discord/lavalink/audio_gateway.go
@@ -75,7 +75,7 @@ func (g *LavalinkAudioGateway) Play(
 		return err
 	}
 
-	track, err := resolveFromLavalink(ctx, g.link, entry.Track().ID())
+	track, err := resolveFromLavalink(ctx, g.link, *entry.Track())
 	if err != nil {
 		return fmt.Errorf("failed to resolve track %q: %w", entry.Track().ID(), err)
 	}

--- a/internal/modules/music_player/infrastructure/discord/lavalink/track_repository.go
+++ b/internal/modules/music_player/infrastructure/discord/lavalink/track_repository.go
@@ -41,7 +41,7 @@ func (r *LavalinkTrackRepository) FindByID(
 	}
 
 	// Cache miss: resolve from Lavalink
-	lavalinkTrack, err := resolveFromLavalink(ctx, r.link, id)
+	lavalinkTrack, err := resolveFromLavalink(ctx, r.link, *track)
 	if err != nil {
 		return domain.Track{}, fmt.Errorf("track %q not found: %w", id, err)
 	}
@@ -66,18 +66,18 @@ func (r *LavalinkTrackRepository) FindByIDs(
 	return tracks, nil
 }
 
-// resolveFromLavalink queries Lavalink to get a fresh track by identifier.
+// resolveFromLavalink queries Lavalink to get a fresh track by URL.
 func resolveFromLavalink(
 	ctx context.Context,
 	link disgolink.Client,
-	trackID domain.TrackID,
+	track domain.Track,
 ) (lavalink.Track, error) {
 	node := link.BestNode()
 	if node == nil {
 		return lavalink.Track{}, fmt.Errorf("no available Lavalink node")
 	}
 
-	result, err := node.LoadTracks(ctx, trackID.String())
+	result, err := node.LoadTracks(ctx, track.URL())
 	if err != nil {
 		return lavalink.Track{}, fmt.Errorf("failed to load track from Lavalink: %w", err)
 	}
@@ -86,14 +86,14 @@ func resolveFromLavalink(
 	case lavalink.Track:
 		return data, nil
 	case lavalink.Empty:
-		return lavalink.Track{}, fmt.Errorf("track %q not found on Lavalink", trackID)
+		return lavalink.Track{}, fmt.Errorf("track %q not found on Lavalink", track.ID())
 	case lavalink.Exception:
 		return lavalink.Track{}, fmt.Errorf(
 			"track resolution raised an exception for track %q: %w",
-			trackID,
+			track.ID(),
 			data,
 		)
 	default:
-		return lavalink.Track{}, fmt.Errorf("invalid track id: %q", trackID)
+		return lavalink.Track{}, fmt.Errorf("invalid track id: %q", track.ID())
 	}
 }


### PR DESCRIPTION
## Summary
- ~~Change `resolveFromLavalink` to accept `domain.Track` instead of `domain.TrackID` and use `track.URL()` for Lavalink queries, fixing track resolution that relied on the track ID string which is not a valid Lavalink load identifier~~
- REVERTED
  https://github.com/sglre6355/sgrbot/pull/47

~~Closes #45~~