### PR TITLE
fix(modules/music_player): resolve tracks by URI instead of identifier

### DIFF
--- a/internal/modules/music_player/application/usecases/add_to_queue.go
+++ b/internal/modules/music_player/application/usecases/add_to_queue.go
@@ -11,7 +11,7 @@ import (
 // AddToQueueInput holds the input for the AddToQueue use case.
 type AddToQueueInput[C comparable] struct {
 	ConnectionInfo C
-	TrackIDs       []string
+	TrackURLs      []string
 	RequesterID    string
 }
 
@@ -21,7 +21,7 @@ type AddToQueueOutput struct {
 	Count      int
 }
 
-// AddToQueue resolves track IDs, creates queue entries, and appends them.
+// AddToQueueUsecase resolves track URLs, creates queue entries, and appends them.
 type AddToQueueUsecase[C comparable] struct {
 	player             *domain.PlayerService
 	playerStates       domain.PlayerStateRepository
@@ -66,12 +66,8 @@ func (uc *AddToQueueUsecase[C]) Execute(
 		return nil, errors.Join(ErrInvalidArgument, err)
 	}
 
-	trackIDs := make([]domain.TrackID, len(input.TrackIDs))
-	for i, tid := range input.TrackIDs {
-		trackIDs[i], err = domain.ParseTrackID(tid)
-		if err != nil {
-			return nil, errors.Join(ErrInvalidArgument, err)
-		}
+	if len(input.TrackURLs) == 0 {
+		return nil, errors.Join(ErrInvalidArgument, errors.New("track URLs must not be empty"))
 	}
 
 	state, err := uc.playerStates.FindByID(ctx, playerStateID)
@@ -79,9 +75,9 @@ func (uc *AddToQueueUsecase[C]) Execute(
 		return nil, errors.Join(ErrInternal, err)
 	}
 
-	entries := make([]domain.QueueEntry, 0, len(trackIDs))
-	for _, tid := range trackIDs {
-		track, err := uc.tracks.FindByID(ctx, tid)
+	entries := make([]domain.QueueEntry, 0, len(input.TrackURLs))
+	for _, url := range input.TrackURLs {
+		track, err := uc.tracks.FindByURL(ctx, url)
 		if err != nil {
 			return nil, errors.Join(ErrInternal, err)
 		}

--- a/internal/modules/music_player/application/usecases/add_to_queue_test.go
+++ b/internal/modules/music_player/application/usecases/add_to_queue_test.go
@@ -41,14 +41,14 @@ func TestAddToQueueUsecase_Execute(t *testing.T) {
 			args: args{
 				input: AddToQueueInput[string]{
 					ConnectionInfo: "guild1",
-					TrackIDs:       []string{"t1"},
+					TrackURLs:      []string{"https://example.com/t1"},
 					RequesterID:    "u1",
 				},
 			},
 			want: want{err: ErrNotConnected},
 		},
 		{
-			name: "empty track ID returns ErrInvalidArgument",
+			name: "empty track URLs returns ErrInvalidArgument",
 			deps: deps{
 				state: func() domain.PlayerState { return newActiveState("existing") },
 				locator: func(id domain.PlayerStateID) *stubPlayerStateLocator {
@@ -58,7 +58,7 @@ func TestAddToQueueUsecase_Execute(t *testing.T) {
 			args: args{
 				input: AddToQueueInput[string]{
 					ConnectionInfo: "guild1",
-					TrackIDs:       []string{""},
+					TrackURLs:      []string{},
 					RequesterID:    "u1",
 				},
 			},
@@ -75,7 +75,7 @@ func TestAddToQueueUsecase_Execute(t *testing.T) {
 			args: args{
 				input: AddToQueueInput[string]{
 					ConnectionInfo: "guild1",
-					TrackIDs:       []string{"t1"},
+					TrackURLs:      []string{"https://example.com/t1"},
 					RequesterID:    "u1",
 				},
 			},
@@ -92,7 +92,7 @@ func TestAddToQueueUsecase_Execute(t *testing.T) {
 			args: args{
 				input: AddToQueueInput[string]{
 					ConnectionInfo: "guild1",
-					TrackIDs:       []string{"t2"},
+					TrackURLs:      []string{"https://example.com/t2"},
 					RequesterID:    "u1",
 				},
 			},
@@ -109,7 +109,7 @@ func TestAddToQueueUsecase_Execute(t *testing.T) {
 			args: args{
 				input: AddToQueueInput[string]{
 					ConnectionInfo: "guild1",
-					TrackIDs:       []string{"t1", "t2"},
+					TrackURLs:      []string{"https://example.com/t1", "https://example.com/t2"},
 					RequesterID:    "u1",
 				},
 			},

--- a/internal/modules/music_player/application/usecases/test.go
+++ b/internal/modules/music_player/application/usecases/test.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
@@ -90,37 +91,37 @@ func (r *stubPlayerStateRepository) Delete(
 // --- Stub: TrackRepository ---
 
 type stubTrackRepository struct {
-	tracks map[domain.TrackID]domain.Track
+	tracks map[string]domain.Track // keyed by URL
 }
 
 func newStubTrackRepo(tracks ...domain.Track) *stubTrackRepository {
-	m := make(map[domain.TrackID]domain.Track, len(tracks))
+	m := make(map[string]domain.Track, len(tracks))
 	for _, t := range tracks {
-		m[t.ID()] = t
+		m[t.URL()] = t
 	}
 	return &stubTrackRepository{tracks: m}
 }
 
-func (r *stubTrackRepository) FindByID(
+func (r *stubTrackRepository) FindByURL(
 	_ context.Context,
-	id domain.TrackID,
+	url string,
 ) (domain.Track, error) {
-	t, ok := r.tracks[id]
+	t, ok := r.tracks[url]
 	if !ok {
-		return domain.Track{}, domain.ErrEmptyTrackID
+		return domain.Track{}, errors.New("track not found")
 	}
 	return t, nil
 }
 
-func (r *stubTrackRepository) FindByIDs(
+func (r *stubTrackRepository) FindByURLs(
 	_ context.Context,
-	ids ...domain.TrackID,
+	urls ...string,
 ) ([]domain.Track, error) {
-	result := make([]domain.Track, 0, len(ids))
-	for _, id := range ids {
-		t, ok := r.tracks[id]
+	result := make([]domain.Track, 0, len(urls))
+	for _, url := range urls {
+		t, ok := r.tracks[url]
 		if !ok {
-			return nil, domain.ErrEmptyTrackID
+			return nil, errors.New("track not found")
 		}
 		result = append(result, t)
 	}

--- a/internal/modules/music_player/domain/track.go
+++ b/internal/modules/music_player/domain/track.go
@@ -135,11 +135,11 @@ func (t *Track) IsStream() bool {
 	return t.isStream
 }
 
-// TrackRepository defines the interface for retrieving tracks by ID.
+// TrackRepository defines the interface for retrieving tracks by URL.
 type TrackRepository interface {
-	// FindByID returns the Track for the given ID, or error if not found.
-	FindByID(ctx context.Context, id TrackID) (Track, error)
+	// FindByURL returns the Track for the given URL, or error if not found.
+	FindByURL(ctx context.Context, url string) (Track, error)
 
-	// FindByIDs returns Tracks for the given IDs, or error if any not found.
-	FindByIDs(ctx context.Context, ids ...TrackID) ([]Track, error)
+	// FindByURLs returns Tracks for the given URLs, or error if any not found.
+	FindByURLs(ctx context.Context, urls ...string) ([]Track, error)
 }

--- a/internal/modules/music_player/infrastructure/discord/lavalink/audio_gateway.go
+++ b/internal/modules/music_player/infrastructure/discord/lavalink/audio_gateway.go
@@ -75,9 +75,9 @@ func (g *LavalinkAudioGateway) Play(
 		return err
 	}
 
-	track, err := resolveFromLavalink(ctx, g.link, entry.Track().ID())
+	track, err := resolveFromLavalink(ctx, g.link, entry.Track().URL())
 	if err != nil {
-		return fmt.Errorf("failed to resolve track %q: %w", entry.Track().ID(), err)
+		return fmt.Errorf("failed to resolve track %q: %w", entry.Track().URL(), err)
 	}
 
 	// Update trackCache with fresh data

--- a/internal/modules/music_player/infrastructure/discord/lavalink/track_cache.go
+++ b/internal/modules/music_player/infrastructure/discord/lavalink/track_cache.go
@@ -8,37 +8,37 @@ import (
 	"github.com/sglre6355/sgrbot/internal/modules/music_player/domain"
 )
 
-// TrackCache is a thread-safe cache for domain Track objects.
+// TrackCache is a thread-safe cache for domain Track objects, keyed by URL.
 type TrackCache struct {
 	mu    sync.RWMutex
-	cache map[domain.TrackID]*domain.Track
+	cache map[string]*domain.Track
 }
 
 // NewTrackCache creates a new TrackCache.
 func NewTrackCache() *TrackCache {
 	return &TrackCache{
-		cache: make(map[domain.TrackID]*domain.Track),
+		cache: make(map[string]*domain.Track),
 	}
 }
 
-// Get returns a cached track by ID, or false if not found.
-func (c *TrackCache) Get(id domain.TrackID) (*domain.Track, bool) {
+// Get returns a cached track by URL, or false if not found.
+func (c *TrackCache) Get(url string) (*domain.Track, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	track, ok := c.cache[id]
+	track, ok := c.cache[url]
 	return track, ok
 }
 
-// Set stores a track in the cache.
-func (c *TrackCache) Set(id domain.TrackID, track *domain.Track) {
+// Set stores a track in the cache by URL.
+func (c *TrackCache) Set(url string, track *domain.Track) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.cache[id] = track
+	c.cache[url] = track
 }
 
-// ConvertAndCache converts a Lavalink track to a domain Track and caches it.
+// ConvertAndCache converts a Lavalink track to a domain Track and caches it by URL.
 func (c *TrackCache) ConvertAndCache(track lavalink.Track) domain.Track {
 	info := track.Info
 	trackID := domain.TrackID(info.Identifier)
@@ -60,7 +60,9 @@ func (c *TrackCache) ConvertAndCache(track lavalink.Track) domain.Track {
 		domain.ParseTrackSource(info.SourceName),
 		info.IsStream,
 	)
-	c.Set(trackID, domainTrack)
+	if uri != "" {
+		c.Set(uri, domainTrack)
+	}
 
 	return *domainTrack
 }

--- a/internal/modules/music_player/infrastructure/discord/lavalink/track_cache_test.go
+++ b/internal/modules/music_player/infrastructure/discord/lavalink/track_cache_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestTrackCache_Get(t *testing.T) {
 	type args struct {
-		setup func(cache *TrackCache)
-		getID domain.TrackID
+		setup  func(cache *TrackCache)
+		getURL string
 	}
 	type want struct {
 		ok    bool
@@ -30,17 +30,17 @@ func TestTrackCache_Get(t *testing.T) {
 						domain.TrackID("abc"), "Title", "Author", time.Minute,
 						"https://example.com", "", domain.TrackSourceYouTube, false,
 					)
-					cache.Set(domain.TrackID("abc"), track)
+					cache.Set("https://example.com", track)
 				},
-				getID: domain.TrackID("abc"),
+				getURL: "https://example.com",
 			},
 			want: want{ok: true, title: "Title"},
 		},
 		{
 			name: "cache miss returns false",
 			args: args{
-				setup: func(_ *TrackCache) {},
-				getID: domain.TrackID("nonexistent"),
+				setup:  func(_ *TrackCache) {},
+				getURL: "https://example.com/nonexistent",
 			},
 			want: want{ok: false},
 		},
@@ -51,7 +51,7 @@ func TestTrackCache_Get(t *testing.T) {
 			cache := NewTrackCache()
 			tt.args.setup(cache)
 
-			got, ok := cache.Get(tt.args.getID)
+			got, ok := cache.Get(tt.args.getURL)
 
 			if ok != tt.want.ok {
 				t.Fatalf("ok: got %v, want %v", ok, tt.want.ok)
@@ -65,7 +65,7 @@ func TestTrackCache_Get(t *testing.T) {
 
 func TestTrackCache_SetOverwrites(t *testing.T) {
 	type args struct {
-		id     domain.TrackID
+		url    string
 		titles []string
 	}
 	type want struct {
@@ -79,7 +79,7 @@ func TestTrackCache_SetOverwrites(t *testing.T) {
 	}{
 		{
 			name: "second set overwrites first",
-			args: args{id: domain.TrackID("abc"), titles: []string{"First", "Second"}},
+			args: args{url: "https://example.com/abc", titles: []string{"First", "Second"}},
 			want: want{title: "Second"},
 		},
 	}
@@ -90,19 +90,19 @@ func TestTrackCache_SetOverwrites(t *testing.T) {
 
 			for _, title := range tt.args.titles {
 				track := domain.ConstructTrack(
-					tt.args.id,
+					domain.TrackID("abc"),
 					title,
 					"A",
 					time.Minute,
-					"",
+					tt.args.url,
 					"",
 					domain.TrackSourceYouTube,
 					false,
 				)
-				cache.Set(tt.args.id, track)
+				cache.Set(tt.args.url, track)
 			}
 
-			got, ok := cache.Get(tt.args.id)
+			got, ok := cache.Get(tt.args.url)
 			if !ok {
 				t.Fatal("expected ok=true")
 			}

--- a/internal/modules/music_player/infrastructure/discord/lavalink/track_repository.go
+++ b/internal/modules/music_player/infrastructure/discord/lavalink/track_repository.go
@@ -29,35 +29,35 @@ func NewLavalinkTrackRepository(
 	}
 }
 
-// FindByID returns the Track for the given ID.
+// FindByURL returns the Track for the given URL.
 // It checks the local cache first, falling back to a Lavalink query on cache miss.
-func (r *LavalinkTrackRepository) FindByID(
+func (r *LavalinkTrackRepository) FindByURL(
 	ctx context.Context,
-	id domain.TrackID,
+	url string,
 ) (domain.Track, error) {
-	track, ok := r.trackCache.Get(id)
+	track, ok := r.trackCache.Get(url)
 	if ok {
 		return *track, nil
 	}
 
 	// Cache miss: resolve from Lavalink
-	lavalinkTrack, err := resolveFromLavalink(ctx, r.link, id)
+	lavalinkTrack, err := resolveFromLavalink(ctx, r.link, url)
 	if err != nil {
-		return domain.Track{}, fmt.Errorf("track %q not found: %w", id, err)
+		return domain.Track{}, fmt.Errorf("track %q not found: %w", url, err)
 	}
 
 	return r.trackCache.ConvertAndCache(lavalinkTrack), nil
 }
 
-// FindByIDs returns Tracks for the given IDs.
+// FindByURLs returns Tracks for the given URLs.
 // It checks the local cache first, falling back to a Lavalink query for cache misses.
-func (r *LavalinkTrackRepository) FindByIDs(
+func (r *LavalinkTrackRepository) FindByURLs(
 	ctx context.Context,
-	ids ...domain.TrackID,
+	urls ...string,
 ) ([]domain.Track, error) {
-	tracks := make([]domain.Track, 0, len(ids))
-	for _, id := range ids {
-		track, err := r.FindByID(ctx, id)
+	tracks := make([]domain.Track, 0, len(urls))
+	for _, url := range urls {
+		track, err := r.FindByURL(ctx, url)
 		if err != nil {
 			return nil, err
 		}
@@ -66,18 +66,18 @@ func (r *LavalinkTrackRepository) FindByIDs(
 	return tracks, nil
 }
 
-// resolveFromLavalink queries Lavalink to get a fresh track by identifier.
+// resolveFromLavalink queries Lavalink to get a fresh track by URL.
 func resolveFromLavalink(
 	ctx context.Context,
 	link disgolink.Client,
-	trackID domain.TrackID,
+	url string,
 ) (lavalink.Track, error) {
 	node := link.BestNode()
 	if node == nil {
 		return lavalink.Track{}, fmt.Errorf("no available Lavalink node")
 	}
 
-	result, err := node.LoadTracks(ctx, trackID.String())
+	result, err := node.LoadTracks(ctx, url)
 	if err != nil {
 		return lavalink.Track{}, fmt.Errorf("failed to load track from Lavalink: %w", err)
 	}
@@ -86,14 +86,14 @@ func resolveFromLavalink(
 	case lavalink.Track:
 		return data, nil
 	case lavalink.Empty:
-		return lavalink.Track{}, fmt.Errorf("track %q not found on Lavalink", trackID)
+		return lavalink.Track{}, fmt.Errorf("track %q not found on Lavalink", url)
 	case lavalink.Exception:
 		return lavalink.Track{}, fmt.Errorf(
 			"track resolution raised an exception for track %q: %w",
-			trackID,
+			url,
 			data,
 		)
 	default:
-		return lavalink.Track{}, fmt.Errorf("invalid track id: %q", trackID)
+		return lavalink.Track{}, fmt.Errorf("invalid track url: %q", url)
 	}
 }

--- a/internal/modules/music_player/presentation/command_handlers.go
+++ b/internal/modules/music_player/presentation/command_handlers.go
@@ -246,15 +246,15 @@ func (h *CommandHandlers) HandlePlay(
 	}
 
 	// Add to queue
-	trackIDs := make([]string, len(resolveOutput.Tracks))
+	trackURLs := make([]string, len(resolveOutput.Tracks))
 	for idx, t := range resolveOutput.Tracks {
-		trackIDs[idx] = t.ID
+		trackURLs[idx] = t.URL
 	}
 	addOutput, err := h.addToQueue.Execute(
 		ctx,
 		usecases.AddToQueueInput[discord.PartialVoiceConnectionInfo]{
 			ConnectionInfo: connectionInfo,
-			TrackIDs:       trackIDs,
+			TrackURLs:      trackURLs,
 			RequesterID:    userID,
 		},
 	)


### PR DESCRIPTION
## Summary
- Resolve tracks via Lavalink using `info.uri` (stable canonical URL) instead of `info.identifier` (source-specific, potentially ephemeral)
- Key track cache by URL instead of identifier
- Rename `TrackRepository.FindByID`/`FindByIDs` to `FindByURL`/`FindByURLs`
- Pass track URLs through the add-to-queue pipeline instead of track IDs

## Test plan
- [x] All existing tests pass with updated assertions
- [x] Play a LavaSrc tracks (Spotify, SoundCloud) to verify the fix

Closes #45